### PR TITLE
Fixed Issue with init state of FCEA

### DIFF
--- a/app/Http/Controllers/FCEA/DashboardController.php
+++ b/app/Http/Controllers/FCEA/DashboardController.php
@@ -309,6 +309,11 @@ class DashboardController extends Controller
 
     private function AddPlaceholderOnJump(Collection $userRanking) : Collection
     {
+        // No need to add separators if there is no data
+        if ($userRanking->isEmpty()) {
+            return $userRanking;
+        }
+
         $lastID = $userRanking->first()->id;
         // Iterate manually to find jumps in id (every id is used at least once) always starting with 1
         foreach ($userRanking as $ranking) {


### PR DESCRIPTION
When no fuirsuit is registerd yet and a user enters the page, he gets softlockt.

This will prevent this, by just not trying to look at data that is not present yet.