### PR TITLE
Remove Double-Sided Option

### DIFF
--- a/app/Http/Controllers/BadgeController.php
+++ b/app/Http/Controllers/BadgeController.php
@@ -75,7 +75,6 @@ class BadgeController extends Controller
 
             // Returns in cents
             $total = BadgeCalculationService::calculate(
-                doubleSided: $validated['upgrades']['doubleSided'],
                 isFreeBadge: $isFreeBadge,
                 isLate: $event->preorder_ends_at->isPast(),
             );
@@ -90,7 +89,7 @@ class BadgeController extends Controller
                 'tax_rate' => 0.19,
                 'tax' => round($tax),
                 'total' => round($total),
-                'dual_side_print' => $validated['upgrades']['doubleSided'],
+                'dual_side_print' => true,
                 'is_free_badge' => $isFreeBadge,
                 'apply_late_fee' => $event->preorder_ends_at->isPast(),
             ]);
@@ -165,10 +164,8 @@ class BadgeController extends Controller
             /**
              * Badge
              */
-            $badge->dual_side_print = $validated['upgrades']['doubleSided'];
             $previousTotal = $badge->total;
             $total = BadgeCalculationService::calculate(
-                doubleSided: $badge->dual_side_print,
                 isFreeBadge: $badge->is_free_badge,
                 isLate: $badge->apply_late_fee,
             );
@@ -183,10 +180,6 @@ class BadgeController extends Controller
             if ($previousTotal !== $total) {
                 $request->user()->forcePay($badge);
             }
-            // Update Extra Copy doulbe sided print
-            Badge::where('extra_copy_of', $badge->id)->update([
-                'dual_side_print' => $validated['upgrades']['doubleSided'],
-            ]);
             return $badge;
         });
         return redirect()->route('badges.index');

--- a/app/Http/Requests/BadgeCreateRequest.php
+++ b/app/Http/Requests/BadgeCreateRequest.php
@@ -22,7 +22,6 @@ class BadgeCreateRequest extends FormRequest
             'catchEmAll' =>  ['required','boolean'],
             'publish' =>  ['required','boolean'],
             'tos' =>  ['required','accepted'],
-            'upgrades.doubleSided' => ['required', 'boolean'],
             'upgrades.spareCopy' => ['required', 'boolean'],
         ];
     }

--- a/app/Http/Requests/BadgeUpdateRequest.php
+++ b/app/Http/Requests/BadgeUpdateRequest.php
@@ -21,7 +21,6 @@ class BadgeUpdateRequest extends FormRequest
             ],
             'catchEmAll' =>  ['required','boolean'],
             'publish' =>  ['required','boolean'],
-            'upgrades.doubleSided' => ['required', 'boolean'],
         ];
     }
 }

--- a/app/Models/Badge/Badge.php
+++ b/app/Models/Badge/Badge.php
@@ -29,6 +29,7 @@ class Badge extends Model implements ProductInterface
         'printed_at' => 'datetime',
         'ready_for_pickup_at' => 'datetime',
         'picked_up_at' => 'datetime',
+        'is_free_badge' => 'boolean',
     ];
 
     public function fursuit(): BelongsTo

--- a/app/Services/BadgeCalculationService.php
+++ b/app/Services/BadgeCalculationService.php
@@ -10,7 +10,6 @@ class BadgeCalculationService
      * Returns the badge fee in cents
      */
     public static function calculate(
-        bool $doubleSided = false,
         bool $isSpareCopy = false,
         bool $isFreeBadge = false,
         bool $isLate = false
@@ -23,9 +22,6 @@ class BadgeCalculationService
         $baseFee = $isFreeBadge ? 0 : 200;
         if ($isLate) {
             $baseFee += 200;
-        }
-        if ($doubleSided) {
-            $baseFee += 100;
         }
         return $baseFee;
     }

--- a/resources/js/Components/BadgeListItem.vue
+++ b/resources/js/Components/BadgeListItem.vue
@@ -112,12 +112,6 @@ function getBadgeTooltipText(status) {
                     <Tag severity="info" value="Discounted Extra Copy"></Tag>
                 </div>
             </div>
-            <div v-if="badge.dual_side_print" class="flex flex-col justify-center px-4 pb-1 md:p-4 gap-2">
-                <!-- dual_side_print, extra_copy badges -->
-                <div class="flex justify-center items-center gap-2">
-                    <Tag value="Dual Side Print"></Tag>
-                </div>
-            </div>
             <!-- Total Price -->
             <div class="flex flex-col justify-center p-4">
                 <p class="text-lg font-semibold font-main">{{ formatEuroFromCents(badge.total) }}</p>

--- a/resources/js/Pages/Badges/BadgesCreate.vue
+++ b/resources/js/Pages/Badges/BadgesCreate.vue
@@ -1,8 +1,6 @@
 <script setup>
 import Layout from "@/Layouts/Layout.vue";
-import {Link, Head, usePage} from '@inertiajs/vue3'
-import Steps from 'primevue/steps';
-import Fieldset from 'primevue/fieldset';
+import {Head, usePage} from '@inertiajs/vue3'
 import InputText from "primevue/inputtext";
 import Dropdown from "primevue/dropdown";
 import Dialog from 'primevue/dialog';
@@ -37,7 +35,6 @@ const form = useForm('post', route('badges.store'), {
     publish: false,
     tos: false,
     upgrades: {
-        doubleSided: false,
         spareCopy: false
     }
 })
@@ -72,9 +69,6 @@ const latePrice = computed(() => {
 
 const total = computed(() => {
     let total = basePrice.value + latePrice.value;
-    if (form.upgrades.doubleSided) {
-        total += 1;
-    }
     if (form.upgrades.spareCopy) {
         total += 2;
     }
@@ -194,24 +188,9 @@ const total = computed(() => {
                 <div class="">
                     <div class="mb-8 ">
                         <h2 class="text-lg font-semibold">Upgrades</h2>
-                        <p>Get a spare copy or get an exclusive double printed badge!</p>
+                        <p>Get a spare copy of your printed badge!</p>
                     </div>
                     <div class="space-y-3">
-                        <div class="flex flex-col md:flex-row gap-8 w-full">
-                            <div class="flex gap-3">
-                                <div class="flex flex-row gap-2 mt-3">
-                                    <InputSwitch v-model="form.upgrades.doubleSided" id="extra1"
-                                                 aria-describedby="extra1-help"/>
-                                </div>
-                                <div>
-                                    <label class="font-semibold block" for="extra1">Double Sided Badge
-                                        <Tag value="+1,00 €"></Tag>
-                                    </label>
-                                    <small
-                                        id="extra1-help">By default our Badges are only Printed on one side. If you want to have a double sided badge, please select this option.</small>
-                                </div>
-                            </div>
-                        </div>
                         <div class="flex flex-col md:flex-row gap-8 w-full">
                             <div class="flex gap-3">
                                 <div class="flex flex-row gap-2 mt-3">
@@ -266,11 +245,6 @@ const total = computed(() => {
                                     <span>{{ latePrice }},00 €</span>
                                 </div>
                                 <small>Orders placed after the Preorder Deadline will be charged a late fee.</small>
-                            </div>
-                            <div v-if="form.upgrades.doubleSided"
-                                 class="flex justify-between border-b border-dotted border-gray-900">
-                                <span>Double Sided Badge</span>
-                                <span>1,00 €</span>
                             </div>
                             <div v-if="form.upgrades.spareCopy"
                                  class="flex justify-between mb-4 border-b border-dotted border-gray-900">

--- a/resources/js/Pages/Badges/BadgesEdit.vue
+++ b/resources/js/Pages/Badges/BadgesEdit.vue
@@ -70,7 +70,7 @@ function imageUpdatedEvent(image) {
 
 const basePrice = computed(() => {
     let price = 0;
-    if (props.badge.is_free_badge === false) {
+    if (props.badge.is_free_badge === false && !props.badge.extra_copy_of) {
         price += 2;
     }
     return price;
@@ -269,6 +269,11 @@ function openImageModal() {
                                  class="flex justify-between border-b border-dotted border-gray-900">
                                 <span>Late Fee</span>
                                 <span>{{ latePrice }},00 €</span>
+                            </div>
+                            <div v-if="props.badge.extra_copy_of"
+                                 class="flex justify-between mb-4 border-b border-dotted border-gray-900">
+                                <span>Spare Copy</span>
+                                <span>2,00 €</span>
                             </div>
                             <!-- End Options -->
                             <div class="flex justify-between text-2xl border-b border-double border-gray-900">

--- a/resources/js/Pages/Badges/BadgesEdit.vue
+++ b/resources/js/Pages/Badges/BadgesEdit.vue
@@ -1,8 +1,6 @@
 <script setup>
 import Layout from "@/Layouts/Layout.vue";
-import {Link, Head, usePage, router} from '@inertiajs/vue3'
-import Steps from 'primevue/steps';
-import Fieldset from 'primevue/fieldset';
+import {Link, Head, router} from '@inertiajs/vue3'
 import InputText from "primevue/inputtext";
 import Dropdown from "primevue/dropdown";
 import Dialog from 'primevue/dialog';
@@ -12,11 +10,8 @@ import {computed, onMounted, reactive, ref} from "vue";
 import Button from 'primevue/button';
 import ImageUpload from "@/Components/BadgeCreator/ImageUpload.vue";
 import Panel from 'primevue/panel';
-import Tag from 'primevue/tag';
-import dayjs from "dayjs";
 import InputError from "@/Components/InputError.vue";
 import Message from 'primevue/message';
-import ConfirmDialog from "primevue/confirmdialog";
 
 const deleteModalOpen = ref(null)
 
@@ -53,9 +48,6 @@ const form = useForm('post', route('badges.update',{badge: props.badge.id}), {
     image: null,
     catchEmAll: props.badge.fursuit.catch_em_all,
     publish: props.badge.fursuit.published,
-    upgrades: {
-        doubleSided: props.badge.dual_side_print
-    }
 },{
     forceFormData: true,
 })
@@ -95,11 +87,7 @@ const total = computed(() => {
     if (props.badge.extra_copy_of) {
         return 2;
     }
-    let total = basePrice.value + latePrice.value;
-    if (form.upgrades.doubleSided && !props.badge.extra_copy_of) {
-        total += 1;
-    }
-    return total;
+    return basePrice.value + latePrice.value;
 })
 
 function openImageModal() {
@@ -260,35 +248,6 @@ function openImageModal() {
                 <!-- End Publish -->
             </div>
             <!-- End Group 2 -->
-            <!-- Paid Extras -->
-            <div>
-                <div class="">
-                    <div class="mb-8 ">
-                        <h2 class="text-lg font-semibold">Upgrades</h2>
-                        <p>Get a double printed badge!</p>
-                    </div>
-                    <div class="space-y-3">
-                        <div class="flex flex-col md:flex-row gap-8 w-full">
-                            <div class="flex gap-3">
-                                <div class="flex flex-row gap-2 mt-3">
-                                    <InputSwitch v-model="form.upgrades.doubleSided"
-                                                 :disabled="!canEdit"
-                                                 id="extra1"
-                                                 aria-describedby="extra1-help"/>
-                                </div>
-                                <div>
-                                    <label class="font-semibold block"  for="extra1">Double Sided Badge
-                                        <Tag value="+1,00 €" v-if="!props.badge.extra_copy_of"></Tag>
-                                    </label>
-                                    <small
-                                        id="extra1-help">By default our Badges are only Printed on one side. If you want to have a double sided badge, please select this option.</small>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- End Paid Extras -->
-            </div>
             <Panel header="Checkout">
                 <template #header>
                     <div class="flex items-center gap-2">
@@ -310,16 +269,6 @@ function openImageModal() {
                                  class="flex justify-between border-b border-dotted border-gray-900">
                                 <span>Late Fee</span>
                                 <span>{{ latePrice }},00 €</span>
-                            </div>
-                            <div v-if="form.upgrades.doubleSided && !props.badge.extra_copy_of"
-                                 class="flex justify-between border-b border-dotted border-gray-900">
-                                <span>Double Sided Badge</span>
-                                <span>1,00 €</span>
-                            </div>
-                            <div v-if="form.upgrades.spareCopy || props.badge.extra_copy_of"
-                                 class="flex justify-between mb-4 border-b border-dotted border-gray-900">
-                                <span>Spare Copy</span>
-                                <span>2,00 €</span>
                             </div>
                             <!-- End Options -->
                             <div class="flex justify-between text-2xl border-b border-double border-gray-900">


### PR DESCRIPTION
Ref #55 

Preseved dual_side_print for the db for compatibility

- Removed options to chose for a Double-Sided Option
- Removed form field
- Removed dependency for server side
- Removed Tag to show that it is a Double-Sided

* Fixed Edit side from accessing data that didn't exists and corrected calculation of baseprice
* Price stays the same as for the single-sided
* Fixed bug where 'is_free_badge === false' is always false because is_free_badge is a number
* Code cleanup

## Create
<img width="1053" height="655" alt="grafik" src="https://github.com/user-attachments/assets/a4fb28c9-967b-4cad-8a7a-49d02cc68ca8" />

## Edit
<img width="1146" height="405" alt="grafik" src="https://github.com/user-attachments/assets/744c95b9-72db-4717-adbb-dfed99dc6095" />
<img width="1139" height="390" alt="grafik" src="https://github.com/user-attachments/assets/0495ee1d-215d-4e76-9956-547c1422f78c" />

## Index (before/after)
<img width="1275" height="315" alt="Screenshot 2025-07-12 204958" src="https://github.com/user-attachments/assets/b62ab98d-9ea5-44b0-a91f-2699df0165d6" />
<img width="1123" height="498" alt="Screenshot 2025-07-12 205330" src="https://github.com/user-attachments/assets/685f5c72-5643-427b-9e21-9313e8d695b4" />

