### PR TITLE
First version of Registration System Intigration

### DIFF
--- a/app/Http/Controllers/BadgeController.php
+++ b/app/Http/Controllers/BadgeController.php
@@ -97,7 +97,7 @@ class BadgeController extends Controller
             // Pay for Badge (force pay as we allow negative balance)
             $request->user()->forcePay($badge);
 
-            if ($isFreeBadge && $request->user()->free_badge_copies > 0) {
+            if ($isFreeBadge) {
                 $total = BadgeCalculationService::calculate(isSpareCopy: true);
                 for ($i = 0; $i < $request->user()->free_badge_copies; $i++) {
                     $clone = $badge->replicate();

--- a/app/Http/Controllers/BadgeController.php
+++ b/app/Http/Controllers/BadgeController.php
@@ -33,8 +33,8 @@ class BadgeController extends Controller
         Gate::authorize('create', Badge::class);
         return Inertia::render('Badges/BadgesCreate', [
             'species' => Species::has('fursuits', count: 5)->orWhere('checked', true)->get('name'),
-            'isFree' => auth()->user()->has_free_badge,
-            'freeBadgeCopies' => auth()->user()->has_free_badge ? auth()->user()->free_badge_copies : 0,
+            'isFree' => auth()->user()->hasFreeBadge(),
+            'freeBadgeCopies' => auth()->user()->hasFreeBadge() ? auth()->user()->free_badge_copies : 0,
         ]);
     }
 
@@ -72,7 +72,7 @@ class BadgeController extends Controller
             ]);
 
             // is Free Badge
-            $isFreeBadge = $request->user()->has_free_badge;
+            $isFreeBadge = $request->user()->hasFreeBadge();
 
             // Returns in cents
             $total = BadgeCalculationService::calculate(

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -74,4 +74,9 @@ class User extends Authenticatable implements FilamentUser, Wallet, WalletFloat,
     {
         return $this->is_admin || $this->is_reviewer;
     }
+
+    public  function hasFreeBadge(): bool
+    {
+        return $this->has_free_badge;
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -51,6 +51,8 @@ class User extends Authenticatable implements FilamentUser, Wallet, WalletFloat,
         'token' => 'encrypted',
         'token_expires_at' => 'datetime',
         'attendee_id' => 'integer',
+        'has_free_badge' => 'bool',
+        "free_badge_copies" => "integer",
     ];
 
     public function badges()

--- a/app/Services/BadgeCalculationService.php
+++ b/app/Services/BadgeCalculationService.php
@@ -19,7 +19,11 @@ class BadgeCalculationService
             return 200;
         }
 
-        $baseFee = $isFreeBadge ? 0 : 200;
+        if ($isFreeBadge) {
+            return 0;
+        }
+
+        $baseFee = 200;
         if ($isLate) {
             $baseFee += 200;
         }

--- a/database/migrations/2025_07_13_181109_add_badge__intigration_to_users_table.php
+++ b/database/migrations/2025_07_13_181109_add_badge__intigration_to_users_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->tinyInteger('has_free_badge')->default(0)->after('remember_token');
+            $table->boolean('has_free_badge')->default(false)->after('remember_token');
             $table->integer('free_badge_copies')->default(0)->after('has_free_badge');
         });
     }

--- a/database/migrations/2025_07_13_181109_add_badge__intigration_to_users_table.php
+++ b/database/migrations/2025_07_13_181109_add_badge__intigration_to_users_table.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->tinyInteger('has_free_badge')->default(0)->after('remember_token');
+            $table->integer('free_badge_copies')->default(0)->after('has_free_badge');
+        });
+    }
+};

--- a/resources/js/Pages/Badges/BadgesCreate.vue
+++ b/resources/js/Pages/Badges/BadgesCreate.vue
@@ -21,7 +21,8 @@ defineOptions({
 
 const props = defineProps({
     species: Array,
-    isFree: Boolean
+    isFree: Boolean,
+    freeBadgeCopies: Number,
 })
 
 const imageModalOpen = ref(false)
@@ -36,7 +37,7 @@ const form = useForm('post', route('badges.store'), {
     publish: false,
     tos: false,
     upgrades: {
-        spareCopy: false
+        spareCopy: props.freeBadgeCopies > 0,
     }
 })
 
@@ -62,17 +63,24 @@ const basePrice = computed(() => {
 })
 
 const latePrice = computed(() => {
-    if (dayjs().isAfter(dayjs(usePage().props.event.preorder_ends_at))) {
+    if (dayjs().isAfter(dayjs(usePage().props.event.preorder_ends_at)) && props.isFree === false) {
         return 2;
     }
     return 0;
 })
 
-const total = computed(() => {
-    let total = basePrice.value + latePrice.value;
-    if (form.upgrades.spareCopy) {
-        total += 2;
+const copiesPrice = computed(() => {
+    let price = 0
+    if (props.freeBadgeCopies > 0) {
+        price += props.freeBadgeCopies * 2;
+    } else if (form.upgrades.spareCopy) {
+        price += 2;
     }
+    return price;
+})
+
+const total = computed(() => {
+    let total = basePrice.value + latePrice.value + copiesPrice.value;
     return total;
 })
 </script>
@@ -202,7 +210,7 @@ const total = computed(() => {
                             <div class="flex gap-3">
                                 <div class="flex flex-row gap-2 mt-3">
                                     <InputSwitch v-model="form.upgrades.spareCopy" id="extra2"
-                                                 aria-describedby="extra2-help"/>
+                                                 aria-describedby="extra2-help" :disabled="props.isFree"/>
                                 </div>
                                 <div>
                                     <label class="font-semibold block" for="extra2">Spare Copy
@@ -254,9 +262,9 @@ const total = computed(() => {
                                 <small>Orders placed after the Preorder Deadline will be charged a late fee.</small>
                             </div>
                             <div v-if="form.upgrades.spareCopy"
-                                 class="flex justify-between mb-4 border-b border-dotted border-gray-900">
-                                <span>Spare Copy</span>
-                                <span>2,00 €</span>
+                                class="flex justify-between mb-4 border-b border-dotted border-gray-900">
+                                <span>Spare Copy{{ props.freeBadgeCopies > 1 ? " x" + props.freeBadgeCopies : "" }}</span>
+                                <span>{{ copiesPrice }},00 €</span>
                             </div>
                             <!-- End Options -->
                             <div class="flex justify-between text-2xl border-b border-double border-gray-900">
@@ -274,6 +282,4 @@ const total = computed(() => {
     </div>
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/resources/js/Pages/Welcome.vue
+++ b/resources/js/Pages/Welcome.vue
@@ -78,12 +78,10 @@ const messages = computed(() => {
             <div v-if="messages.showButtons" class="w-full">
                 <div class="flex flex-col md:flex-row gap-3 text-white w-full"
                      v-if="usePage().props.auth.user !== null">
-                    <!-- Action Select -->
-                    <Button @click="router.visit(route('badges.create'))" icon="pi pi-id-card" class="w-full" v-if="usePage().props.auth.user.badges.length === 0 && showState === 'preorder'" label="Claim your first free Fursuit Badge!"/>
                     <!-- Claim Additional Fursuit Badges -->
-                    <Button @click="router.visit(route('badges.create'))" icon="pi pi-id-card" class="w-full" v-else-if="usePage().props.auth.user.badges.length === 0">Get your first Fursuit Badge!</Button>
+                    <Button @click="router.visit(route('badges.create'))" icon="pi pi-id-card" class="w-full" v-if="usePage().props.auth.user.has_free_badge" label="Customize First Fursuit Badge"/>
                     <!-- Buy Additional Fursuit Badges -->
-                    <Button @click="router.visit(route('badges.create'))" icon="pi pi-id-card" severity="warning" v-if="usePage().props.auth.user.badges.length > 0" class="w-full"
+                    <Button @click="router.visit(route('badges.create'))" icon="pi pi-id-card" severity="warning" class="w-full" v-if="!usePage().props.auth.user.has_free_badge"
                             label="Buy Additional Fursuit Badges"/>
                     <!-- Manage Badges -->
                     <Button @click="router.visit(route('badges.index'))"  icon="pi pi-id-card" class="w-full" v-if="usePage().props.auth.user.badges.length > 0" label="Review Ordered Badges"/>
@@ -130,14 +128,14 @@ const messages = computed(() => {
         </p>
         <div class="mt-4">
             <h1 class="text-2xl font-semibold font-main">How to Get Your Badge:</h1>
-            <ul class="list-disc pl-6 mt-2">
-                <li class="mt-2">
+            <ul class="list-disc pl-6 mt-2 gap-2 flex flex-col">
+                <li>
                     <strong>First Preoder Badge Free:</strong> Simply register for Eurofurence and get your first fursuit badge for free.
                 </li>
-                <li class="mt-2">
+                <li>
                     <strong>Additional Badges & Late Orders:</strong> Order more for just 2 € each.
                 </li>
-                <li class="mt-2">
+                <li>
                     <strong>On-Site Services:</strong> Need a last-minute badge? We’ve got you covered with our late printing service for a small fee.
                 </li>
             </ul>

--- a/resources/js/Pages/Welcome.vue
+++ b/resources/js/Pages/Welcome.vue
@@ -80,8 +80,10 @@ const messages = computed(() => {
                      v-if="usePage().props.auth.user !== null">
                     <!-- Claim Additional Fursuit Badges -->
                     <Button @click="router.visit(route('badges.create'))" icon="pi pi-id-card" class="w-full" v-if="usePage().props.auth.user.has_free_badge" label="Customize First Fursuit Badge"/>
+                    <Button @click="router.visit(route('badges.create'))" icon="pi pi-id-card" severity="warning" class="w-full" v-if="usePage().props.auth.user.badges.length === 0 && !usePage().props.auth.user.has_free_badge"
+                            label="Buy Fursuit Badges"/>
                     <!-- Buy Additional Fursuit Badges -->
-                    <Button @click="router.visit(route('badges.create'))" icon="pi pi-id-card" severity="warning" class="w-full" v-if="!usePage().props.auth.user.has_free_badge"
+                    <Button @click="router.visit(route('badges.create'))" icon="pi pi-id-card" severity="warning" class="w-full" v-if="usePage().props.auth.user.badges.length > 0"
                             label="Buy Additional Fursuit Badges"/>
                     <!-- Manage Badges -->
                     <Button @click="router.visit(route('badges.index'))"  icon="pi pi-id-card" class="w-full" v-if="usePage().props.auth.user.badges.length > 0" label="Review Ordered Badges"/>

--- a/tests/Feature/BadgeTest.php
+++ b/tests/Feature/BadgeTest.php
@@ -16,6 +16,10 @@ uses(RefreshDatabase::class);
 
 beforeEach(function () {
     $this->user = User::factory()->create();
+    $this->user->update([
+        'has_free_badge' => true,
+        'free_badge_copies' => 1,
+    ]);
     $event = \App\Models\Event::factory()->create([
         'starts_at' => \Carbon\Carbon::parse('2024-06-01'),
         'ends_at' => \Carbon\Carbon::parse('2024-06-30'),

--- a/tests/Feature/BadgeTest.php
+++ b/tests/Feature/BadgeTest.php
@@ -17,8 +17,8 @@ uses(RefreshDatabase::class);
 beforeEach(function () {
     $this->user = User::factory()->create();
     $this->user->update([
-        'has_free_badge' => true,
-        'free_badge_copies' => 1,
+        'has_free_badge' => false,
+        'free_badge_copies' => 0,
     ]);
     $event = \App\Models\Event::factory()->create([
         'starts_at' => \Carbon\Carbon::parse('2024-06-01'),


### PR DESCRIPTION
SEE #62 

---

# OUTDATED (will be closed after #62)
 * Modified Creator to display the correct amount of money to pay nad locks the spareCopy option if  it is the from the system approved one
 * Added fields for user table to represent the current state of the system approved badge
 * Altert the badge create buttons on the welcome page
 * Backend can now also process the system approved badge

- Late fee will be ignored for the free one

## Has badge enabled in reg
<img width="1369" height="868" alt="Screenshot 2025-07-13 195746" src="https://github.com/user-attachments/assets/c5b629b1-e137-4fef-a926-f120b08171fc" />
<img width="1157" height="548" alt="Screenshot 2025-07-13 200019" src="https://github.com/user-attachments/assets/27e798cd-e70d-48cb-b240-54daf4096141" />

### With copies
<img width="1125" height="546" alt="Screenshot 2025-07-13 195754" src="https://github.com/user-attachments/assets/0497224d-8161-4acd-8ab9-5c7875b90bb7" />
<img width="1101" height="1253" alt="Screenshot 2025-07-13 195814" src="https://github.com/user-attachments/assets/c560ede8-991b-4719-aa57-0828c66a68b7" />

## No badge enabled
<img width="1296" height="335" alt="grafik" src="https://github.com/user-attachments/assets/7efe37cc-2890-452e-beb9-8c10b9828777" />
