### PR TITLE
Streamline catch page

### DIFF
--- a/app/Domain/CatchEmAll/Controllers/GameController.php
+++ b/app/Domain/CatchEmAll/Controllers/GameController.php
@@ -31,27 +31,7 @@ class GameController extends Controller
 
     public function index(Request $request)
     {
-        $user = Auth::user();
-        $selectedEventId = $request->get('event');
-
-        // Get event
         $selectedEvent = $this->getCurrentEvent(); // TODO: Add fetch method for Selected Event based on filter
-        $eventUser = $this->getEventUser($user, $selectedEvent);
-
-        // Get user's game stats
-        $gameStats = $this->gameStatsService->getUserStats($eventUser);
-
-        // Get leaderboard data
-        $leaderboard = $this->gameStatsService->getLeaderboard($selectedEvent);
-
-        // Get user's collection progress
-        $collection = $this->gameStatsService->getUserCollection($eventUser);
-
-        // Get user's achievements
-        $achievements = AchievementFactory::getUserAchievementData($eventUser);
-
-        // Get events for filter dropdown
-        $eventsWithEntries = $this->getEventsWithEntries();
 
         $isGameRunning = $selectedEvent?->isCatchEmAllActive();
 
@@ -62,12 +42,6 @@ class GameController extends Controller
         }
 
         return Inertia::render('CatchEmAll/Catch', [
-            'gameStats' => $gameStats,
-            'leaderboard' => $leaderboard,
-            'collection' => $collection,
-            'achievements' => $achievements,
-            'eventsWithEntries' => $eventsWithEntries,
-            'selectedEvent' => $selectedEvent?->id,
             'recentCatch' => $recentCatch,
             'isGameRunning' => $isGameRunning,
             'code' => $request->has('code') ? $request->input('code') : '',

--- a/resources/js/Pages/CatchEmAll/Catch.vue
+++ b/resources/js/Pages/CatchEmAll/Catch.vue
@@ -1,17 +1,7 @@
 <script setup lang="ts">
 import CatchEmAllLayout from "@/Layouts/CatchEmAllLayout.vue";
 import { useForm } from "@inertiajs/vue3";
-import {
-    Award,
-    BookOpen,
-    Crown,
-    Star,
-    Target,
-    TrendingUp,
-    Trophy,
-    User,
-    Zap,
-} from "lucide-vue-next";
+import { Star, Target, User, Zap } from "lucide-vue-next";
 import Button from "primevue/button";
 import Card from "primevue/card";
 import Dialog from "primevue/dialog";
@@ -19,15 +9,6 @@ import InputText from "primevue/inputtext";
 import { computed, nextTick, onMounted, ref } from "vue";
 
 const props = defineProps<{
-    gameStats: {
-        rank: number;
-        totalCatches: number;
-        uniqueSpecies: number;
-        totalAvailable: number;
-        completionPercentage: number;
-        rarityStats: Record<string, any>;
-    };
-    achievements: Array<any>;
     recentCatch?: any | null;
     flash?: any;
     isGameRunning: boolean;
@@ -104,14 +85,6 @@ onMounted(() => {
         form.reset();
     });
 });
-
-const getRankIcon = (rank: number) => {
-    if (rank === 1) return Crown;
-    if (rank === 2) return Trophy;
-    if (rank === 3) return Award;
-    if (rank <= 10) return Star;
-    return TrendingUp;
-};
 </script>
 
 <template>
@@ -201,87 +174,6 @@ const getRankIcon = (rank: number) => {
                 </Button>
             </div>
         </Dialog>
-
-        <!-- Stats Overview Card -->
-        <Card class="bg-gray-800 border border-gray-700 shadow-sm">
-            <template #content>
-                <div class="space-y-4">
-                    <!-- User Stats Row -->
-                    <div class="flex items-center justify-between">
-                        <div class="flex items-center space-x-3">
-                            <div
-                                class="w-12 h-12 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center"
-                            >
-                                <component
-                                    :is="getRankIcon(gameStats.rank)"
-                                    class="w-6 h-6 text-white"
-                                />
-                            </div>
-                            <div>
-                                <div class="text-lg font-bold text-gray-100">
-                                    Rank #{{ gameStats.rank }}
-                                </div>
-                                <div class="text-sm text-gray-300">
-                                    {{
-                                        gameStats.totalCatches.toLocaleString()
-                                    }}
-                                    catches
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Progress Bar -->
-                    <div class="space-y-2">
-                        <div class="flex justify-between text-sm">
-                            <span class="text-gray-300">Progress</span>
-                            <span class="font-medium"
-                                >{{ gameStats.completionPercentage }}%</span
-                            >
-                        </div>
-                        <div
-                            class="h-2 bg-gray-200 rounded-full overflow-hidden"
-                        >
-                            <div
-                                class="h-full bg-gradient-to-r from-blue-500 to-purple-600 rounded-full transition-all duration-500"
-                                :style="`width: ${gameStats.completionPercentage}%`"
-                            ></div>
-                        </div>
-                        <div class="text-xs text-gray-400 text-center">
-                            {{ gameStats.totalCatches }} /
-                            {{ gameStats.totalAvailable }} fursuiters
-                        </div>
-                    </div>
-
-                    <!-- Quick Stats Grid -->
-                    <div class="grid grid-cols-2 gap-2 pt-2">
-                        <div class="text-center p-3 bg-blue-900/20 rounded-lg">
-                            <BookOpen
-                                class="w-5 h-5 mx-auto mb-1 text-blue-400"
-                            />
-                            <div class="text-lg font-bold text-blue-400">
-                                {{ gameStats.uniqueSpecies }}
-                            </div>
-                            <div class="text-xs text-blue-300">Species</div>
-                        </div>
-                        <div class="text-center p-3 bg-green-900/20 rounded-lg">
-                            <Award
-                                class="w-5 h-5 mx-auto mb-1 text-green-400"
-                            />
-                            <div class="text-lg font-bold text-green-400">
-                                {{
-                                    achievements.filter((a) => a.completed)
-                                        .length
-                                }}
-                            </div>
-                            <div class="text-xs text-green-300">
-                                Achievements
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </template>
-        </Card>
 
         <!-- Code Input Card -->
         <Card class="bg-gray-800 border border-gray-700 shadow-sm">


### PR DESCRIPTION
Removal of profile information from catch screen and reduction in data needed on index load

<img width="301" height="691" alt="image" src="https://github.com/user-attachments/assets/587dee1f-28a3-4f65-862d-2089108423d9" />

With keyboard
<img width="301" height="691" alt="image" src="https://github.com/user-attachments/assets/6a91a030-44d8-4c55-81b7-c55eeb6e6896" />

Errors are still served at top but more visible
<img width="301" height="691" alt="image" src="https://github.com/user-attachments/assets/d60ee04f-ffc5-4d6f-9902-d9ea64f46b4d" />

