### PR TITLE
Admin badge print filters

### DIFF
--- a/app/Filament/Resources/BadgeResource.php
+++ b/app/Filament/Resources/BadgeResource.php
@@ -14,6 +14,7 @@ use App\Models\Badge\State_Fulfillment\Processing;
 use App\Models\Badge\State_Payment\BadgePaymentStatusState;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -40,6 +41,15 @@ class BadgeResource extends Resource
         }
 
         return (string) Badge::whereHas('fursuit', fn ($q) => $q->where('event_id', $eventId))->count();
+    }
+
+    /** Active badge printers, lowest id first so the default pick is stable. */
+    protected static function badgePrinters(): \Illuminate\Database\Eloquent\Builder
+    {
+        return Printer::query()
+            ->where('type', PrintJobTypeEnum::Badge)
+            ->where('is_active', true)
+            ->orderBy('id');
     }
 
     public static function form(Form $form): Form
@@ -229,7 +239,8 @@ class BadgeResource extends Resource
                             ->on('fursuits.event_id', '=', 'event_users.event_id');
                     })
                     ->select('badges.*')
-                    ->addSelect('event_users.attendee_id as sort_attendee_id');
+                    ->addSelect('event_users.attendee_id as sort_attendee_id')
+                    ->addSelect('fursuits.approved_at as fursuit_approved_at');
             })
             ->columns([
                 // Fursuit Image as first column
@@ -349,6 +360,13 @@ class BadgeResource extends Resource
                     ->dateTime('M j, Y')
                     ->toggleable(isToggledHiddenByDefault: true),
 
+                Tables\Columns\TextColumn::make('fursuit_approved_at')
+                    ->label('Approved At')
+                    ->dateTime('M j, Y H:i')
+                    ->placeholder('Not approved')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+
                 Tables\Columns\TextColumn::make('printed_at')
                     ->label('Printed At')
                     ->dateTime('M j, Y H:i')
@@ -425,6 +443,44 @@ class BadgeResource extends Resource
 
                         return $indicators;
                     }),
+
+                // Print cutoff. Everything approved up to the last print run is already
+                // filed in the box, so the next run should only pick up what was approved
+                // after it. `approved_from` is filled in automatically by the bulk print
+                // action below and persists in the session.
+                Tables\Filters\Filter::make('approved_at_range')
+                    ->label('Approval Cutoff')
+                    ->form([
+                        Forms\Components\DateTimePicker::make('approved_from')
+                            ->label('Approved from')
+                            ->helperText('Set automatically after each bulk print. Clear it to show every badge again.'),
+                        Forms\Components\DateTimePicker::make('approved_until')
+                            ->label('Approved until'),
+                    ])
+                    ->query(function ($query, array $data) {
+                        return $query
+                            ->when($data['approved_from'] ?? null, function ($query, $from) {
+                                return $query->whereHas('fursuit', function ($q) use ($from) {
+                                    $q->where('approved_at', '>=', $from);
+                                });
+                            })
+                            ->when($data['approved_until'] ?? null, function ($query, $until) {
+                                return $query->whereHas('fursuit', function ($q) use ($until) {
+                                    $q->where('approved_at', '<=', $until);
+                                });
+                            });
+                    })
+                    ->indicateUsing(function (array $data): array {
+                        $indicators = [];
+                        if ($data['approved_from'] ?? null) {
+                            $indicators[] = 'Approved from '.\Carbon\Carbon::parse($data['approved_from'])->format('M j, H:i');
+                        }
+                        if ($data['approved_until'] ?? null) {
+                            $indicators[] = 'Approved until '.\Carbon\Carbon::parse($data['approved_until'])->format('M j, H:i');
+                        }
+
+                        return $indicators;
+                    }),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),
@@ -445,18 +501,15 @@ class BadgeResource extends Resource
                     ->form([
                         Forms\Components\Select::make('printer_id')
                             ->label('Select Printer')
-                            ->options(
-                                Printer::where('type', PrintJobTypeEnum::Badge)
-                                    ->where('is_active', true)
-                                    ->pluck('name', 'id')
-                            )
+                            ->options(fn () => static::badgePrinters()->pluck('name', 'id'))
+                            ->default(fn () => static::badgePrinters()->value('id'))
                             ->required()
                             ->helperText('Select a specific printer for all selected badges.'),
                     ])
                     ->requiresConfirmation()
                     ->modalHeading('Print Selected Badges')
                     ->modalDescription('This will print all selected badges to the specified printer.')
-                    ->action(function (Collection $records, array $data) {
+                    ->action(function (Collection $records, array $data, $livewire) {
                         $printerId = $data['printer_id'];
                         // sort by attendee id numerically
                         $sortedRecords = $records->sortBy(fn (Badge $badge) => (int) $badge->sort_attendee_id);
@@ -482,6 +535,28 @@ class BadgeResource extends Resource
                             ->onQueue('batch-print')
                             ->allowFailures()
                             ->dispatch();
+
+                        // This run is now filed in the box. Move the approval cutoff up to
+                        // the newest badge in it so the next run only offers what came in
+                        // afterwards, instead of re-listing everything already printed.
+                        $latestApprovedAt = $sortedRecords
+                            ->pluck('fursuit_approved_at')
+                            ->filter()
+                            ->max();
+
+                        if ($latestApprovedAt) {
+                            $filters = $livewire->tableFilters ?? [];
+                            $filters['approved_at_range']['approved_from'] = (string) $latestApprovedAt;
+
+                            $livewire->tableFilters = $filters;
+                            $livewire->updatedTableFilters();
+
+                            Notification::make()
+                                ->title('Approval cutoff moved to '.\Carbon\Carbon::parse($latestApprovedAt)->format('M j, H:i'))
+                                ->body('Badges approved before this run are hidden. Clear the Approval Cutoff filter to see them again.')
+                                ->success()
+                                ->send();
+                        }
 
                         return true;
                     }),

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ use App\Models\Badge\Badge;
 use App\Models\Fursuit\Fursuit;
 use App\Models\SumUpReader;
 use App\Providers\Socialite\SocialiteIdentityProvider;
+use Filament\Tables\Table;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Socialite\Contracts\Factory;
@@ -26,6 +27,16 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Keep table filters/search/sort when navigating away from a list page
+        // (e.g. editing a record and returning) instead of resetting them.
+        Table::configureUsing(function (Table $table): void {
+            $table
+                ->persistFiltersInSession()
+                ->persistSearchInSession()
+                ->persistColumnSearchesInSession()
+                ->persistSortInSession();
+        });
+
         Fursuit::observe(\App\Observers\FursuitObserver::class);
         Badge::observe(\App\Observers\BadgeObserver::class);
         TseClient::observe(\App\Observers\TseClientsObserver::class);


### PR DESCRIPTION
Admin badge list changes aimed at the on-site print workflow.

## Keep table filters across navigation

Filters reset whenever you left a list page (edit a record, save, come back). `Table::configureUsing()` in `AppServiceProvider` now turns on `persistFiltersInSession`, `persistSearchInSession`, `persistColumnSearchesInSession` and `persistSortInSession` for every Filament table, so state survives the round trip.

Session keys are per Livewire component, so filters do not leak between resources. Any resource can opt out with `->persistFiltersInSession(false)` in its own `table()`.

## Approval cutoff filter on badges

Badges ordered during a print run used to show up in the next run, so the same badges got re-listed and the box went out of order.

New `Approval Cutoff` filter on the badge list filters on `fursuits.approved_at` (from / until). The bulk print action sets `approved_from` to the newest `approved_at` in the run it just dispatched, so the next run only offers what came in afterwards. Value persists in the session via the change above. Clear the filter to see everything again.

Also adds an `Approved At` column (toggleable, hidden by default) so the cutoff can be sanity-checked against the actual data.

Known limitation: an attendee who registered early but is approved late has a low attendee ID and a recent timestamp, so the cutoff lets that badge into the new run and it has to be filed by hand. Attendee-ID based cutoff was the alternative but needs a stored high-water mark; date was chosen as the simpler option.

## Default badge printer

The bulk print printer select was empty by default. Now defaults to the first active badge printer (lowest id, so it is stable). Options and default share one `badgePrinters()` query.

## Testing

Not run. `composer install` fails in this environment: the shell PHP is 8.5.9 and several locked packages (`mpdf/mpdf`, `nette/schema`, `openspout/openspout`, `brianium/paratest`) cap at 8.4, so `vendor/filament*` is absent. Changes are PHP-lint clean only, and need a check on `/admin/badges`:

- filters survive edit and save
- bulk print sets the cutoff and the notification shows the right timestamp
- printer select is pre-filled
