### PR TITLE
POS badge verification mode

### DIFF
--- a/app/Http/Controllers/Manage/BadgeController.php
+++ b/app/Http/Controllers/Manage/BadgeController.php
@@ -393,11 +393,13 @@ class BadgeController extends Controller
     }
 
     /**
-     * The audit's fourteen columns, in order, with the old panel's own labels verbatim.
+     * The audit's fourteen columns, in order, with the old panel's own labels verbatim,
+     * followed by Verified, which is not the audit's.
      *
      * Five are hidden by default, which is every `isToggledHiddenByDefault: true` flag
      * the old badge list carries: extra_copy, total, created_at, printed_at, picked_up_at
-     *.
+     *. Verified is hidden too: it is read with the print_verified filter when a crate is
+     * being reconciled, and is noise the rest of the time.
      *
      * @return array<int, Column>
      */
@@ -441,6 +443,12 @@ class BadgeController extends Controller
             Column::datetime('picked_up_at', 'Picked Up')
                 ->toggleable(hiddenByDefault: true)
                 ->fallback('Not picked up'),
+            // The card was seen: either the print agent's camera saw it come out,
+            // or somebody typed its number off the physical card at the desk. What
+            // is printed and never verified is what has to be reprinted.
+            Column::datetime('verified_print_at', 'Verified')
+                ->toggleable(hiddenByDefault: true)
+                ->fallback('Not verified'),
         ];
     }
 
@@ -481,6 +489,7 @@ class BadgeController extends Controller
             'created_at' => $this->datetime($badge->created_at, self::DATE_FORMAT),
             'printed_at' => $this->datetime($badge->printed_at),
             'picked_up_at' => $this->datetime($badge->picked_up_at),
+            'verified_print_at' => $this->datetime($badge->verified_print_at),
         ];
     }
 
@@ -527,7 +536,8 @@ class BadgeController extends Controller
     }
 
     /**
-     * The audit's four filters.
+     * The audit's four filters, the two approval bounds added with the print cutoff, and
+     * the verification filter added with the POS check-off screen.
      *
      * @return array<int, Filter>
      */
@@ -576,6 +586,19 @@ class BadgeController extends Controller
             Filter::datetime('approved_until', 'Approved until')
                 ->chipLabel('Approved before')
                 ->apply(fn (Builder $query, string $value) => $this->applyApprovedBound($query, '<=', $value)),
+
+            // The reprint list. Set this to "Not verified", the fulfillment status to
+            // the printed states and the attendee range to the crate that was just
+            // checked off at the desk, and what is left is the cards that were
+            // printed and never turned up. See BadgeVerificationController.
+            Filter::ternary('print_verified', 'Print Verified')
+                ->placeholder('Verified or not')
+                ->trueLabel('Verified')
+                ->falseLabel('Not verified')
+                ->chipLabel('Verification')
+                ->apply(fn (Builder $query, string $value) => $value === '1'
+                    ? $query->whereNotNull('badges.verified_print_at')
+                    : $query->whereNull('badges.verified_print_at')),
         ];
     }
 

--- a/app/Http/Controllers/POS/BadgeVerificationController.php
+++ b/app/Http/Controllers/POS/BadgeVerificationController.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace App\Http\Controllers\POS;
+
+use App\Domain\Printing\Models\PrintJob;
+use App\Enum\PrintJobStatusEnum;
+use App\Enum\PrintVerificationSourceEnum;
+use App\Http\Controllers\Controller;
+use App\Models\Badge\Badge;
+use App\Models\Event;
+use App\Models\EventUser;
+use App\Models\Machine;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+
+/**
+ * Checking a printed card off against the stack in front of you.
+ *
+ * The desk holds a crate of finished cards. Somebody reads the number off every
+ * card and types it, the card is verified, and whatever is still unverified at
+ * the end of the crate is what never came out of the printer and has to be
+ * reprinted. That is the whole feature: a numpad, a running list, and an undo.
+ *
+ * It writes the same `verified_print_at` the print agent writes, with
+ * `verification_source = operator`, because "a human looked at the card and
+ * confirmed it" is exactly what happened. A card verified here is never
+ * un-verified by a later reprint - the stamp says the card was seen once, and
+ * the admin list is filtered on it to find the ones that never were.
+ */
+class BadgeVerificationController extends Controller
+{
+    /**
+     * The fulfillment states a physical card exists in.
+     *
+     * @var array<int, string>
+     */
+    private const PRINTED_STATES = ['printed', 'ready_for_pickup', 'picked_up'];
+
+    /**
+     * The screen: counters for the crate, and the tail of the check-off list.
+     *
+     * The list is read back from the database rather than kept in the browser,
+     * so it survives a lock, a reload and a second clerk working the same crate.
+     */
+    public function index(Request $request)
+    {
+        $event = Event::getActiveEvent();
+        $machine = auth('machine')->user();
+
+        if (! $event) {
+            return redirect()->route('pos.dashboard')->with('error', 'No current event found');
+        }
+
+        $printed = $this->printedBadges($event, $machine);
+
+        return Inertia::render('POS/Verification/Index', [
+            'stats' => [
+                'printed' => (clone $printed)->count(),
+                'verified' => (clone $printed)->whereNotNull('badges.verified_print_at')->count(),
+                'missing' => (clone $printed)->whereNull('badges.verified_print_at')->count(),
+            ],
+            'badgeRange' => [
+                'min' => $machine?->badge_range_min,
+                'max' => $machine?->badge_range_max,
+            ],
+            'recent' => $this->recent($event),
+            // The verdict on the number just typed. It rides the session rather
+            // than the shared flash bag, which only carries success/error strings
+            // and is read by the toast layer; this one is a small structure the
+            // page renders itself.
+            'result' => fn () => $request->session()->get('verification'),
+        ]);
+    }
+
+    /**
+     * Check one card off.
+     *
+     * A bare attendee number means their first badge, because that is what all
+     * but a handful of them have: `1234` is `1234-1`. A second copy has to be
+     * typed in full as `1234-2`, since guessing which copy is in your hand is
+     * exactly the mistake this screen exists to catch.
+     */
+    public function store(Request $request)
+    {
+        $event = Event::getActiveEvent();
+
+        if (! $event) {
+            return back()->with('error', 'No current event found');
+        }
+
+        $customId = $this->normalizeBadgeId((string) $request->input('badge_id', ''));
+
+        if ($customId === null) {
+            return back()->with('verification', [
+                'status' => 'error',
+                'message' => 'Not a badge number. Type 1234 or 1234-2.',
+                'input' => trim((string) $request->input('badge_id', '')),
+            ]);
+        }
+
+        $badge = Badge::whereHas('fursuit', fn (Builder $q) => $q->where('event_id', $event->id))
+            ->with(['fursuit.user'])
+            ->where('custom_id', $customId)
+            ->first();
+
+        if (! $badge) {
+            return back()->with('verification', [
+                'status' => 'error',
+                'message' => $this->missingBadgeReason($event, $customId),
+                'input' => $customId,
+            ]);
+        }
+
+        if ($badge->verified_print_at !== null) {
+            return back()->with('verification', [
+                'status' => 'duplicate',
+                'message' => $customId.' was already checked off '.$badge->verified_print_at->diffForHumans().'.',
+                'input' => $customId,
+                'badge' => $this->badgeRow($badge),
+            ]);
+        }
+
+        $this->verify($badge);
+
+        return back()->with('verification', [
+            'status' => 'ok',
+            'message' => $customId.' checked off.',
+            'input' => $customId,
+            'badge' => $this->badgeRow($badge->fresh(['fursuit.user'])),
+        ]);
+    }
+
+    /**
+     * Undo one check-off, for the card typed as `1234-1` that was `1234-2`.
+     *
+     * Clears the stamp on the badge and on its print jobs, so the card falls
+     * back into the unverified list and the batch counters agree with it again.
+     */
+    public function revert(Badge $badge)
+    {
+        if ($badge->verified_print_at === null) {
+            return back()->with('verification', [
+                'status' => 'error',
+                'message' => ($badge->custom_id ?? 'That badge').' was not checked off.',
+                'input' => $badge->custom_id,
+            ]);
+        }
+
+        DB::transaction(function () use ($badge) {
+            $badge->printJobs()
+                ->whereNotNull('verified_print_at')
+                ->get()
+                ->each(function (PrintJob $job) {
+                    $job->update([
+                        'verified_print_at' => null,
+                        'verification_source' => null,
+                        'verified_by_id' => null,
+                    ]);
+
+                    $job->batch?->recalculateCounters();
+                });
+
+            $badge->forceFill(['verified_print_at' => null])->saveQuietly();
+
+            activity()
+                ->performedOn($badge)
+                ->withProperties(['staff' => auth('machine-user')->user()?->name])
+                ->log('Badge check-off reverted at the desk');
+        });
+
+        return back()->with('verification', [
+            'status' => 'reverted',
+            'message' => ($badge->custom_id ?? 'Badge').' put back on the missing list.',
+            'input' => $badge->custom_id,
+        ]);
+    }
+
+    /**
+     * Stamp the card, through the print job where there is one.
+     *
+     * `PrintJob::markVerified()` is what the agent calls, and it mirrors the
+     * stamp onto the badge and recounts the batch. A badge printed before print
+     * jobs existed, or whose job was pruned, still has to be checkable off, so
+     * the badge is stamped directly in that case.
+     */
+    private function verify(Badge $badge): void
+    {
+        DB::transaction(function () use ($badge) {
+            $job = $badge->printJobs()
+                ->where('status', PrintJobStatusEnum::Printed)
+                ->orderByDesc('printed_at')
+                ->first()
+                ?? $badge->printJobs()->orderByDesc('id')->first();
+
+            if ($job) {
+                // No `verified_by`: that column points at `users`, and the person
+                // at the desk is a `staff` row. The activity log below carries who.
+                $job->markVerified(PrintVerificationSourceEnum::Operator);
+            } else {
+                $badge->forceFill(['verified_print_at' => now()])->saveQuietly();
+            }
+
+            activity()
+                ->performedOn($badge)
+                ->withProperties(['staff' => auth('machine-user')->user()?->name])
+                ->log('Badge checked off at the desk');
+        });
+    }
+
+    /**
+     * `1234` -> `1234-1`, `1234-2` -> `1234-2`, anything else -> null.
+     *
+     * Numpad and scanner both emit stray characters, and the numpad's minus is
+     * the only separator on the keypad, so a dash is the one non-digit allowed.
+     */
+    private function normalizeBadgeId(string $raw): ?string
+    {
+        $value = trim(str_replace(['–', '—', ' '], ['-', '-', ''], $raw));
+
+        if (preg_match('/^\d+$/', $value)) {
+            return $value.'-1';
+        }
+
+        if (preg_match('/^(\d+)-(\d+)$/', $value, $matches)) {
+            return $matches[1].'-'.$matches[2];
+        }
+
+        return null;
+    }
+
+    /**
+     * Why a typed number found nothing, phrased for somebody holding a card.
+     *
+     * "No such badge" is useless at the desk: the interesting split is between a
+     * number nobody at this event has and an attendee whose card has not been
+     * printed, because only the second one is a card that should be in the crate.
+     */
+    private function missingBadgeReason(Event $event, string $customId): string
+    {
+        [$attendeeId, $copy] = explode('-', $customId, 2);
+
+        $attendeeExists = EventUser::where('event_id', $event->id)
+            ->where('attendee_id', $attendeeId)
+            ->exists();
+
+        if (! $attendeeExists) {
+            return 'No attendee '.$attendeeId.' at this event.';
+        }
+
+        $printedCopies = Badge::whereHas('fursuit', fn (Builder $q) => $q->where('event_id', $event->id))
+            ->where('custom_id', 'like', $attendeeId.'-%')
+            ->pluck('custom_id')
+            ->sort()
+            ->values();
+
+        if ($printedCopies->isEmpty()) {
+            return 'Attendee '.$attendeeId.' has no printed badge. Card should not be in the box.';
+        }
+
+        return 'Attendee '.$attendeeId.' has no copy '.$copy.'. Printed: '.$printedCopies->implode(', ').'.';
+    }
+
+    /**
+     * Printed cards of this event, narrowed to the crate this desk holds.
+     *
+     * "Printed" is the fulfillment state, not `printed_at`. Only `ToPrinted`
+     * stamps that column, and the print pipeline does not go through it: a job
+     * finishing calls `promoteBadgeToReadyForPickup()`, which transitions
+     * straight to ReadyForPickup. Filtering on the timestamp counted zero cards
+     * on live data while the crate was full of them.
+     */
+    private function printedBadges(Event $event, ?Machine $machine): Builder
+    {
+        $query = Badge::whereHas('fursuit', fn (Builder $q) => $q->where('event_id', $event->id))
+            ->whereNotNull('badges.custom_id')
+            ->where(fn (Builder $q) => $q
+                ->whereIn('badges.status_fulfillment', self::PRINTED_STATES)
+                ->orWhereNotNull('badges.printed_at'));
+
+        $this->applyBadgeRange($query, $event, $machine);
+
+        return $query;
+    }
+
+    /**
+     * The crate this desk holds, same rule as the dashboard counter.
+     */
+    private function applyBadgeRange(Builder $query, Event $event, ?Machine $machine): void
+    {
+        if (! $machine || ! $machine->hasBadgeRange()) {
+            return;
+        }
+
+        $query->whereHas('fursuit.user.eventUsers', function ($q) use ($event, $machine) {
+            $q->where('event_id', $event->id);
+
+            if ($machine->badge_range_min !== null) {
+                $q->whereRaw('CAST(attendee_id AS SIGNED) >= ?', [$machine->badge_range_min]);
+            }
+
+            if ($machine->badge_range_max !== null) {
+                $q->whereRaw('CAST(attendee_id AS SIGNED) <= ?', [$machine->badge_range_max]);
+            }
+        });
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function recent(Event $event): array
+    {
+        // Every checked-off card of this event, not only the ones the counters
+        // count, and not narrowed to this desk's crate. Anything typed into the
+        // field can be checked off, so anything typed into the field has to
+        // appear here - a screen that answers "checked off" and then shows an
+        // empty list reads as the check-off having failed.
+        return Badge::whereHas('fursuit', fn (Builder $q) => $q->where('event_id', $event->id))
+            ->whereNotNull('badges.verified_print_at')
+            ->with(['fursuit.user'])
+            ->orderByDesc('badges.verified_print_at')
+            ->orderByDesc('badges.id')
+            ->limit(30)
+            ->get()
+            ->map(fn (Badge $badge) => $this->badgeRow($badge))
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function badgeRow(Badge $badge): array
+    {
+        return [
+            'id' => $badge->id,
+            'custom_id' => $badge->custom_id,
+            'fursuit_name' => $badge->fursuit?->name,
+            'owner_name' => $badge->fursuit?->user?->name,
+            'verified_at' => $badge->verified_print_at?->toIso8601String(),
+        ];
+    }
+}

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -159,6 +159,39 @@ different questions answered by different calls. `verified_print_at` and `verifi
 No camera images are ever uploaded to the server. Only the verdict. (The optional Telegram channel
 posts photos to a chat, which is a separate, opt-in channel; see below.)
 
+**The desk check-off** is the third way a card gets verified, and the only one that proves the card
+is in the building. `/pos/verification` (F8) is a numpad, a running list and an undo: somebody reads
+the number off every card in the crate and types it, and each entry stamps `verified_print_at`
+through `PrintJob::markVerified()` with `verification_source = operator`, exactly as the agent's own
+operator verdict does. What is left over at the end of the crate - printed, never checked off - is
+what never came out of the printer, and is found in `/admin` by filtering the badge list on
+**Print Verified = Not verified** plus the fulfillment status and the attendee range that crate
+covers.
+
+Two rules on that screen, both learned from cards going out twice:
+
+- A bare number is copy 1. `1234` checks off `1234-1`; a second copy has to be typed as `1234-2`,
+  because nothing on the screen can tell which copy is in the operator's hand.
+- The stamp is never cleared by a later reprint. It records that the card was seen once. The undo
+  button is the only thing that clears it, for the number typed off the wrong card.
+
+The counters read "printed" off the fulfillment state, never off `badges.printed_at`. Only the
+`ToPrinted` transition stamps that column and the print pipeline does not go through it - a finished
+job calls `promoteBadgeToReadyForPickup()` - so on live data the timestamp is null for every card the
+agent printed. The screen counted zero cards against a full crate until that was fixed. The list
+below the counters is deliberately wider than them: it shows every card checked off at this event,
+including ones outside the desk's crate, because anything the field accepts has to appear there.
+
+The screen is also shaped nothing like the dashboard, which is one keystroke away and is also a
+number field over a keypad. An attendee number typed into the wrong one would check a card off
+without anybody noticing, so this one wears a banner, puts the list where the dashboard puts the
+keypad, and shrinks the keypad to a touchscreen fallback.
+
+The auto-lock is suspended on that route alone. Working a crate is minutes of handling cards with no
+keyboard or mouse in between, and locking there discards the list of what was already checked; the
+page polls the server every minute to hold the session instead. The screen shows no attendee data
+and no till, so the lock protects nothing there.
+
 ## Printer condition
 
 The agent polls SNMP and reduces the reading to a `PrinterConditionEnum` case, which the POS shows

--- a/resources/js/Components/POS/InactivityTimer.vue
+++ b/resources/js/Components/POS/InactivityTimer.vue
@@ -64,8 +64,16 @@ const isTimerActive = computed(() => {
         return false;
     }
 
-    // Timer is active on all POS routes except auth routes
-    const isActive = currentRoute.value && currentRoute.value.startsWith('pos.') && !currentRoute.value.startsWith('pos.auth.');
+    // Timer is active on all POS routes except auth routes, and except the
+    // verification screen. Checking a crate off is minutes of handling cards
+    // with no keyboard or mouse in between, and locking there throws away the
+    // list of what was already checked - the one thing the clerk is reading
+    // off the screen. That screen holds no attendee data and no till, so the
+    // lock buys nothing there; it polls the server itself to hold the session.
+    const isActive = currentRoute.value
+        && currentRoute.value.startsWith('pos.')
+        && !currentRoute.value.startsWith('pos.auth.')
+        && !currentRoute.value.startsWith('pos.verification.');
     console.log('[InactivityTimer] Route check:', {
         currentRoute: currentRoute.value,
         isActive,

--- a/resources/js/Components/POS/ShortcutsDialog.vue
+++ b/resources/js/Components/POS/ShortcutsDialog.vue
@@ -14,6 +14,7 @@
       <div><b>Print Queue:</b> <kbd>F4</kbd></div>
       <div><b>Statistics:</b> <kbd>F6</kbd></div>
       <div><b>My Print Jobs:</b> <kbd>F7</kbd></div>
+      <div><b>Badge Verification:</b> <kbd>F8</kbd></div>
       <div><b>This dialog:</b> <kbd>F1</kbd></div>
 
       <h4 class="pos-label mb-2 mt-4">Keyboard</h4>

--- a/resources/js/Pages/POS/Dashboard.vue
+++ b/resources/js/Pages/POS/Dashboard.vue
@@ -219,6 +219,13 @@ const actions = computed(() => [
         count: props.printNotifications.length || null,
     },
     {
+        label: 'Badge Verification',
+        subtitle: 'Check a printed box off',
+        route: route('pos.verification.index'),
+        icon: 'pi pi-check-square',
+        key: 'F8',
+    },
+    {
         label: 'Statistics',
         subtitle: 'Reports & totals',
         route: route('pos.statistics'),

--- a/resources/js/Pages/POS/Verification/Index.vue
+++ b/resources/js/Pages/POS/Verification/Index.vue
@@ -1,0 +1,280 @@
+<script setup>
+import { Head, router, useForm } from "@inertiajs/vue3";
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
+import POSLayout from "@/Layouts/POSLayout.vue";
+import { usePosKeyboard } from "@/composables/usePosKeyboard";
+
+defineOptions({
+    layout: POSLayout,
+});
+
+const props = defineProps({
+    stats: Object,
+    badgeRange: Object,
+    recent: {
+        type: Array,
+        default: () => [],
+    },
+    result: {
+        type: Object,
+        default: null,
+    },
+});
+
+const badgeIdInput = ref(null);
+
+const form = useForm({
+    badge_id: "",
+});
+
+function focusInput() {
+    nextTick(() => badgeIdInput.value?.focus());
+}
+
+function submit() {
+    if (! form.badge_id || form.processing) {
+        return;
+    }
+
+    form.post(route("pos.verification.store"), {
+        preserveScroll: true,
+        onFinish: () => {
+            // Cleared either way: a rejected number stays visible in the banner,
+            // and leaving it in the field means the next card gets typed onto
+            // the end of it.
+            form.badge_id = "";
+            focusInput();
+        },
+    });
+}
+
+// The numpad has a minus key, so a second copy can be typed as 1234-2 without
+// leaving the keypad. A bare number is the first copy; the server decides that.
+function keyPress(key) {
+    if (key === "delete") {
+        form.badge_id = form.badge_id.slice(0, -1);
+    } else if (key === "enter") {
+        submit();
+    } else {
+        form.badge_id += key;
+    }
+    focusInput();
+}
+
+function revert(badge) {
+    router.post(route("pos.verification.revert", { badge: badge.id }), {}, {
+        preserveScroll: true,
+        onFinish: focusInput,
+    });
+}
+
+// Scanners and the keypad emit stray characters; digits and one dash are the
+// whole alphabet of a badge number.
+watch(() => form.badge_id, (value) => {
+    const cleaned = (value || "").replace(/[^\d-]/g, "").slice(0, 12);
+    if (cleaned !== value) {
+        form.badge_id = cleaned;
+    }
+});
+
+// Numpad "/" is "start over" here rather than "go to the dashboard": the field
+// on this screen is the one the clerk is already typing into.
+usePosKeyboard({
+    onNumpadDivide: () => {
+        form.badge_id = "";
+        focusInput();
+    },
+});
+
+/* --- Keeping the screen alive -------------------------------------------- */
+
+// Working a crate means long silences: read a card, put it on the pile, pick up
+// the next one. The auto-lock is suspended for this route (InactivityTimer), and
+// this poll is the other half of it - it keeps the session from expiring under
+// the same silence, and refreshes the list when a second desk works the same
+// crate. Nothing typed is held in the browser, so a reload loses nothing.
+let keepAliveTimer = null;
+
+onMounted(() => {
+    focusInput();
+    keepAliveTimer = setInterval(() => {
+        router.reload({
+            only: ["stats", "recent"],
+            preserveState: true,
+            preserveScroll: true,
+        });
+    }, 60000);
+});
+
+onUnmounted(() => clearInterval(keepAliveTimer));
+
+/* --- Presentation --------------------------------------------------------- */
+
+const rangeLabel = computed(() => {
+    const min = props.badgeRange?.min;
+    const max = props.badgeRange?.max;
+
+    if (min !== null && min !== undefined && max !== null && max !== undefined) {
+        return `attendee ${min} to ${max}`;
+    }
+    if (min !== null && min !== undefined) {
+        return `attendee ${min} and up`;
+    }
+    if (max !== null && max !== undefined) {
+        return `attendee up to ${max}`;
+    }
+
+    return "every badge of the event";
+});
+
+// Counters read as one line of text rather than as the dashboard's stat tiles.
+// The two screens are one keystroke apart and both are a number field over a
+// keypad, so this one deliberately does not look like the other: typing an
+// attendee number into the wrong one silently checks a card off.
+const counters = computed(() => [
+    { label: "checked off", value: props.stats?.verified ?? 0 },
+    { label: "still missing", value: props.stats?.missing ?? 0, bad: true },
+    { label: `printed · ${rangeLabel.value}`, value: props.stats?.printed ?? 0 },
+]);
+
+const resultClass = computed(() => ({
+    ok: "border-pos-good text-pos-good",
+    duplicate: "border-pos-warn text-pos-warn",
+    reverted: "border-pos-line text-pos-muted",
+    error: "border-pos-bad text-pos-bad",
+}[props.result?.status] ?? "border-pos-line text-pos-muted"));
+
+function verifiedTime(row) {
+    if (! row.verified_at) {
+        return "";
+    }
+
+    return new Date(row.verified_at).toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+    });
+}
+</script>
+
+<template>
+    <Head>
+        <title>POS - Badge Verification</title>
+    </Head>
+
+    <!-- Nothing on this screen is shaped like the dashboard: the banner runs the
+         full width, the list is the big half, and the entry column sits on the
+         right with a keypad half the size. The two screens are one keystroke
+         apart and a number typed into the wrong one checks a card off silently. -->
+    <div class="w-full flex-1 flex flex-col gap-2">
+        <div class="rounded-pos border-2 border-pos-warn bg-pos-warn/10 px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+            <div>
+                <h1 class="text-base font-bold tracking-wide uppercase text-pos-warn">
+                    Verification mode
+                </h1>
+                <p class="text-xs text-pos-muted">
+                    Reading numbers off the cards in the box. Nothing is handed out and no attendee is looked up here.
+                </p>
+            </div>
+
+            <div class="flex items-center gap-4">
+                <div v-for="counter in counters" :key="counter.label" class="text-right">
+                    <span
+                        class="block pos-num text-2xl font-bold leading-none"
+                        :class="counter.bad && counter.value > 0 ? 'text-pos-bad' : ''"
+                    >{{ counter.value }}</span>
+                    <span class="block text-[0.68rem] uppercase tracking-wide text-pos-muted">{{ counter.label }}</span>
+                </div>
+            </div>
+        </div>
+
+        <div class="flex-1 grid grid-cols-1 lg:grid-cols-5 gap-2">
+            <section class="lg:col-span-3 pos-card flex flex-col">
+                <div class="pos-card__head">
+                    <h2>Checked off in this box</h2>
+                    <span class="text-xs text-pos-muted">
+                        {{ recent.length ? `last ${recent.length}` : 'nothing yet' }}
+                    </span>
+                </div>
+
+                <p v-if="!recent.length" class="text-sm text-pos-muted px-1 py-4">
+                    Type the number printed on the first card to start. Every card you check off
+                    lands here, newest first, with an Undo beside it.
+                </p>
+
+                <div v-else class="pos-block pos-block--rows w-full flex-1 max-h-[34rem] overflow-y-auto">
+                    <div v-for="row in recent" :key="row.id" class="pos-row">
+                        <div class="pos-row__body">
+                            <span class="pos-row__title pos-num text-lg">{{ row.custom_id }}</span>
+                            <span class="pos-row__sub">
+                                {{ verifiedTime(row) }}
+                                · {{ row.fursuit_name || 'unknown fursuit' }}
+                                <template v-if="row.owner_name"> · {{ row.owner_name }}</template>
+                            </span>
+                        </div>
+                        <button
+                            type="button"
+                            class="pos-btn pos-btn--quiet"
+                            @click="revert(row)"
+                        >
+                            Undo
+                        </button>
+                    </div>
+                </div>
+            </section>
+
+            <section class="lg:col-span-2 pos-card flex flex-col self-start w-full">
+                <div class="pos-card__head">
+                    <h2>Card number</h2>
+                    <div class="flex items-center gap-2 text-xs text-pos-muted">
+                        <span><span class="pos-kcap mr-1">Enter</span>check off</span>
+                        <span><span class="pos-kcap mr-1">/</span>clear</span>
+                    </div>
+                </div>
+
+                <p
+                    v-if="result"
+                    class="mb-2 px-3 py-2 rounded-pos border text-sm font-semibold"
+                    :class="resultClass"
+                    aria-live="polite"
+                >
+                    {{ result.message }}
+                </p>
+                <p v-else class="mb-2 text-xs text-pos-muted">
+                    A bare number is copy 1: 1234 checks off 1234-1. A second copy needs
+                    1234-2 typed in full.
+                </p>
+
+                <form class="flex flex-col gap-2" @submit.prevent="submit">
+                    <input
+                        ref="badgeIdInput"
+                        v-model="form.badge_id"
+                        class="pos-field text-center"
+                        type="text"
+                        inputmode="numeric"
+                        autocomplete="off"
+                        placeholder="0000-0"
+                        maxlength="12"
+                    />
+                    <button
+                        type="submit"
+                        class="pos-btn pos-btn--primary pos-btn--commit"
+                        :disabled="!form.badge_id || form.processing"
+                    >
+                        Check off <span class="pos-kcap">Enter</span>
+                    </button>
+                </form>
+
+                <!-- Half the dashboard keypad's size: the desk numpad does the typing,
+                     and this is the fallback for a touchscreen. -->
+                <div class="pos-keypad w-full max-w-[15rem] mx-auto mt-3">
+                    <button v-for="n in ['7','8','9','4','5','6','1','2','3']" :key="n"
+                            type="button" class="pos-key" @click="keyPress(n)">{{ n }}</button>
+                    <button type="button" class="pos-key" @click="keyPress('-')">-</button>
+                    <button type="button" class="pos-key" @click="keyPress('0')">0</button>
+                    <button type="button" class="pos-key pos-key--wide" @click="keyPress('delete')">Delete</button>
+                </div>
+            </section>
+        </div>
+    </div>
+</template>

--- a/resources/js/composables/usePosKeyboard.js
+++ b/resources/js/composables/usePosKeyboard.js
@@ -48,6 +48,7 @@ export function usePosKeyboard(options = {}) {
         F6: '/pos/statistics',
         // F5 is the browser reload and stays out of this map; F7 is free.
         F7: '/pos/my-prints',
+        F8: '/pos/verification',
     };
 
     function handleKeydown(event) {

--- a/routes/pos.php
+++ b/routes/pos.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\POS\AttendeeController;
 use App\Http\Controllers\POS\BadgeController;
 use App\Http\Controllers\POS\BadgeEditController;
 use App\Http\Controllers\POS\BadgeManagementController;
+use App\Http\Controllers\POS\BadgeVerificationController;
 use App\Http\Controllers\POS\CheckoutController;
 use App\Http\Controllers\POS\DashboardController;
 use App\Http\Controllers\POS\MachineController;
@@ -56,6 +57,12 @@ Route::prefix('/my-prints')->name('my-prints.')->group(function () {
     Route::get('/', [MyPrintsController::class, 'index'])->name('index');
     Route::post('/dismiss-all', [MyPrintsController::class, 'dismissAll'])->name('dismiss-all');
     Route::post('/{printBatch}/dismiss', [MyPrintsController::class, 'dismiss'])->name('dismiss');
+});
+// Checking the printed crate off card by card. See BadgeVerificationController.
+Route::prefix('/verification')->name('verification.')->group(function () {
+    Route::get('/', [BadgeVerificationController::class, 'index'])->name('index');
+    Route::post('/', [BadgeVerificationController::class, 'store'])->name('store');
+    Route::post('/{badge}/revert', [BadgeVerificationController::class, 'revert'])->name('revert');
 });
 // Statistics
 Route::get('/statistics', [StatisticsController::class, 'index'])->name('statistics');

--- a/tests/Feature/Manage/BadgesTest.php
+++ b/tests/Feature/Manage/BadgesTest.php
@@ -16,6 +16,8 @@
  *  - a badge whose fursuit or user is soft-deleted took the whole table down.
  *
  * The rest is parity, transcribed from the audit: fourteen columns in order, four filters,
+ * plus what was added afterwards - the Verified column and the print_verified filter that
+ * the POS check-off screen is read through.
  * five form sections, and the old panel's own delete copy.
  */
 
@@ -104,7 +106,7 @@ beforeEach(function () {
     ]);
 });
 
-test('the list renders the fourteen columns in order, with their labels and types', function () {
+test('the list renders the fifteen columns in order, with their labels and types', function () {
     ($this->badge)();
 
     ($this->scoped)(null)->get(route('admin.badges.index'))
@@ -125,9 +127,12 @@ test('the list renders the fourteen columns in order, with their labels and type
             ->where('columns.11', fn ($c) => $c['key'] === 'created_at' && $c['label'] === 'Created' && $c['hiddenByDefault'])
             ->where('columns.12', fn ($c) => $c['key'] === 'printed_at' && $c['label'] === 'Printed At' && $c['fallback'] === 'Not printed' && $c['hiddenByDefault'])
             ->where('columns.13', fn ($c) => $c['key'] === 'picked_up_at' && $c['label'] === 'Picked Up' && $c['fallback'] === 'Not picked up' && $c['hiddenByDefault'])
-            ->count('columns', 14)
-            // The five isToggledHiddenByDefault: true flags, and only those five.
-            ->where('hiddenColumns', ['extra_copy', 'total', 'created_at', 'printed_at', 'picked_up_at'])
+            // Column 15 is not the audit's: it is the desk check-off, added with the POS
+            // verification screen so the printed-but-never-seen cards can be listed.
+            ->where('columns.14', fn ($c) => $c['key'] === 'verified_print_at' && $c['label'] === 'Verified' && $c['fallback'] === 'Not verified' && $c['hiddenByDefault'])
+            ->count('columns', 15)
+            // The five isToggledHiddenByDefault: true flags from the audit, plus Verified.
+            ->where('hiddenColumns', ['extra_copy', 'total', 'created_at', 'printed_at', 'picked_up_at', 'verified_print_at'])
         );
 });
 
@@ -184,7 +189,7 @@ test('the attendee-id sort flips through the partial reload the client actually 
         // The five requested keys have to carry data, not null.
         ->and($descending->json('props.meta.page'))->toBe(1)
         ->and($descending->json('props.search'))->toBe('')
-        ->and($descending->json('props.filters'))->toHaveCount(6);
+        ->and($descending->json('props.filters'))->toHaveCount(7);
 
     expect($partial(['sort' => 'sort_attendee_id', 'dir' => 'asc'])->json('props.rows.0.id'))->toBe($ninth->id);
 });
@@ -319,7 +324,7 @@ test('the list declares its filters with their labels, placeholders and option s
 
     ($this->scoped)(null)->get(route('admin.badges.index'))
         ->assertInertia(fn (Assert $page) => $page
-            ->count('filters', 6)
+            ->count('filters', 7)
             ->where('filters.0.key', 'status_fulfillment')
             ->where('filters.0.label', 'Fulfillment Status')
             ->where('filters.0.placeholder', 'All Statuses')
@@ -358,6 +363,14 @@ test('the list declares its filters with their labels, placeholders and option s
             ->where('filters.5.type', 'datetime')
             ->where('filters.5.label', 'Approved until')
             ->where('filters.5.chipLabel', 'Approved before')
+            // Not the audit's either: the reprint list. Printed, and never checked off
+            // at the desk or seen by the print agent's camera.
+            ->where('filters.6.key', 'print_verified')
+            ->where('filters.6.type', 'ternary')
+            ->where('filters.6.label', 'Print Verified')
+            ->where('filters.6.placeholder', 'Verified or not')
+            ->where('filters.6.trueLabel', 'Verified')
+            ->where('filters.6.falseLabel', 'Not verified')
             // Nothing is filtered on first load; every filter opens blank.
             ->where('filters.0.value', [])
             ->where('filters.1.value', [])
@@ -365,6 +378,7 @@ test('the list declares its filters with their labels, placeholders and option s
             ->where('filters.3.value', ['min' => '', 'max' => ''])
             ->where('filters.4.value', '')
             ->where('filters.5.value', '')
+            ->where('filters.6.value', '')
         );
 });
 

--- a/tests/Feature/POS/BadgeVerificationTest.php
+++ b/tests/Feature/POS/BadgeVerificationTest.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace Tests\Feature\POS;
+
+use App\Domain\Printing\Models\PrintJob;
+use App\Enum\PrintJobStatusEnum;
+use App\Enum\PrintJobTypeEnum;
+use App\Enum\PrintVerificationSourceEnum;
+use App\Models\Badge\Badge;
+use App\Models\Event;
+use App\Models\EventUser;
+use App\Models\Fursuit\Fursuit;
+use App\Models\Machine;
+use App\Models\Species;
+use App\Models\Staff;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Checking a crate of printed cards off, card by card.
+ *
+ * The screen exists to answer one question at the end of the crate: which cards
+ * were printed and never turned up. Everything here is a way of getting that
+ * answer wrong - a copy checked off in place of its sibling, a number typed
+ * twice, a card checked off that is not in your hand.
+ */
+class BadgeVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Event $event;
+
+    private Machine $machine;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->event = Event::factory()->create([
+            'starts_at' => now()->subDay(),
+            'ends_at' => now()->addDay(),
+            'order_starts_at' => now()->subDays(10),
+            'order_ends_at' => now()->subDays(5),
+        ]);
+
+        $this->machine = Machine::factory()->create();
+
+        $this->actingAs($this->machine, 'machine')
+            ->actingAs(Staff::factory()->create(['name' => 'Desk staff']), 'machine-user');
+    }
+
+    /**
+     * A printed badge belonging to one attendee, with its custom_id already
+     * allocated - which is what the fulfillment transition does, and what the
+     * number on the physical card is.
+     */
+    private function printedBadge(string $attendeeId, int $copy = 1): Badge
+    {
+        $user = User::factory()->create();
+
+        EventUser::factory()->create([
+            'user_id' => $user->id,
+            'event_id' => $this->event->id,
+            'attendee_id' => $attendeeId,
+        ]);
+
+        return $this->copyFor($user, $attendeeId, $copy);
+    }
+
+    private function copyFor(User $user, string $attendeeId, int $copy): Badge
+    {
+        $fursuit = Fursuit::factory()->create([
+            'user_id' => $user->id,
+            'event_id' => $this->event->id,
+            'species_id' => Species::factory()->create()->id,
+            'status' => 'approved',
+        ]);
+
+        return Badge::factory()->create([
+            'fursuit_id' => $fursuit->id,
+            'custom_id' => $attendeeId.'-'.$copy,
+            'status_fulfillment' => 'ready_for_pickup',
+            'status_payment' => 'paid',
+            'printed_at' => now()->subHour(),
+        ]);
+    }
+
+    private function printJobFor(Badge $badge): PrintJob
+    {
+        return PrintJob::factory()->create([
+            'printable_type' => $badge::class,
+            'printable_id' => $badge->id,
+            'type' => PrintJobTypeEnum::Badge,
+            'status' => PrintJobStatusEnum::Printed,
+            'printed_at' => now()->subHour(),
+        ]);
+    }
+
+    public function test_a_bare_attendee_number_checks_off_the_first_copy(): void
+    {
+        $badge = $this->printedBadge('1234');
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234'])
+            ->assertRedirect();
+
+        $this->assertNotNull($badge->fresh()->verified_print_at);
+    }
+
+    public function test_a_second_copy_has_to_be_typed_in_full(): void
+    {
+        $first = $this->printedBadge('1234');
+        $second = $this->copyFor($first->fursuit->user, '1234', 2);
+
+        // The bare number is copy 1 and nothing else: guessing which copy is in
+        // the operator's hand is the mistake this screen exists to catch.
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234']);
+
+        $this->assertNotNull($first->fresh()->verified_print_at);
+        $this->assertNull($second->fresh()->verified_print_at);
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234-2']);
+
+        $this->assertNotNull($second->fresh()->verified_print_at);
+    }
+
+    public function test_the_stamp_goes_through_the_print_job_so_the_agent_and_the_desk_agree(): void
+    {
+        $badge = $this->printedBadge('1234');
+        $job = $this->printJobFor($badge);
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234']);
+
+        $job->refresh();
+
+        $this->assertNotNull($job->verified_print_at);
+        $this->assertSame(PrintVerificationSourceEnum::Operator, $job->verification_source);
+        $this->assertNotNull($badge->fresh()->verified_print_at);
+    }
+
+    public function test_a_badge_with_no_print_job_is_still_checkable_off(): void
+    {
+        $badge = $this->printedBadge('1234');
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234']);
+
+        $this->assertNotNull($badge->fresh()->verified_print_at);
+    }
+
+    public function test_a_number_typed_twice_says_so_and_keeps_the_first_stamp(): void
+    {
+        $badge = $this->printedBadge('1234');
+
+        $this->travelTo(now()->subMinutes(10));
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234']);
+        $this->travelBack();
+
+        $stamped = $badge->fresh()->verified_print_at;
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234'])
+            ->assertSessionHas('verification', fn (array $result) => $result['status'] === 'duplicate');
+
+        $this->assertTrue($badge->fresh()->verified_print_at->equalTo($stamped));
+    }
+
+    public function test_an_unknown_attendee_and_a_missing_copy_are_told_apart(): void
+    {
+        $this->printedBadge('1234');
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '9999'])
+            ->assertSessionHas('verification', fn (array $result) => $result['status'] === 'error'
+                && str_contains($result['message'], 'No attendee 9999'));
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234-3'])
+            ->assertSessionHas('verification', fn (array $result) => $result['status'] === 'error'
+                && str_contains($result['message'], 'no copy 3'));
+    }
+
+    public function test_a_number_that_is_not_a_badge_number_is_refused(): void
+    {
+        $this->post(route('pos.verification.store'), ['badge_id' => 'abc'])
+            ->assertSessionHas('verification', fn (array $result) => $result['status'] === 'error');
+    }
+
+    public function test_undo_puts_the_card_back_on_the_missing_list(): void
+    {
+        $badge = $this->printedBadge('1234');
+        $job = $this->printJobFor($badge);
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234']);
+        $this->post(route('pos.verification.revert', ['badge' => $badge->id]))
+            ->assertRedirect();
+
+        $this->assertNull($badge->fresh()->verified_print_at);
+        $this->assertNull($job->fresh()->verified_print_at);
+        $this->assertNull($job->fresh()->verification_source);
+    }
+
+    public function test_the_screen_counts_the_crate_and_lists_what_was_checked_off(): void
+    {
+        $checked = $this->printedBadge('1234');
+        $this->printedBadge('1235');
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234']);
+
+        $this->get(route('pos.verification.index'))
+            ->assertSuccessful()
+            ->assertInertia(fn ($page) => $page
+                ->component('POS/Verification/Index')
+                ->where('stats.printed', 2)
+                ->where('stats.verified', 1)
+                ->where('stats.missing', 1)
+                ->where('recent.0.custom_id', $checked->custom_id)
+                ->count('recent', 1)
+                ->etc()
+            );
+    }
+
+    public function test_a_card_the_print_pipeline_promoted_still_counts(): void
+    {
+        // The print pipeline never goes through ToPrinted: a finished job calls
+        // promoteBadgeToReadyForPickup(), so printed_at stays null on every card
+        // printed by the agent. Counting on that column read zero cards on live
+        // data while the crate was full of them.
+        $badge = $this->printedBadge('1234');
+        $badge->forceFill(['printed_at' => null])->saveQuietly();
+
+        $this->get(route('pos.verification.index'))
+            ->assertInertia(fn ($page) => $page
+                ->where('stats.printed', 1)
+                ->where('stats.missing', 1)
+                ->etc()
+            );
+    }
+
+    public function test_a_checked_off_card_always_shows_in_the_list(): void
+    {
+        // Outside this desk's crate, so the counters ignore it - but it was
+        // typed into this field, so the list has to show it. Answering
+        // "checked off" over an empty list reads as a failed check-off.
+        $this->machine->update(['badge_range_min' => 1000, 'badge_range_max' => 1999]);
+
+        $this->printedBadge('2500');
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '2500']);
+
+        $this->get(route('pos.verification.index'))
+            ->assertInertia(fn ($page) => $page
+                ->where('recent.0.custom_id', '2500-1')
+                ->count('recent', 1)
+                ->etc()
+            );
+    }
+
+    public function test_the_counters_follow_the_crate_this_desk_holds(): void
+    {
+        $this->machine->update(['badge_range_min' => 1000, 'badge_range_max' => 1999]);
+
+        $this->printedBadge('1234');
+        $this->printedBadge('2500');
+
+        $this->get(route('pos.verification.index'))
+            ->assertInertia(fn ($page) => $page
+                ->where('stats.printed', 1)
+                ->where('stats.missing', 1)
+                ->etc()
+            );
+    }
+
+    public function test_the_screen_needs_a_signed_in_staff_member(): void
+    {
+        auth('machine-user')->logout();
+        auth('machine')->logout();
+
+        $this->get(route('pos.verification.index'))->assertRedirect();
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234'])->assertRedirect();
+    }
+}


### PR DESCRIPTION
Checking a crate of printed cards off, card by card, so the ones that never came out of the printer can be found and reprinted.

## The POS screen

`/pos/verification`, F8, open to any signed-in POS staff. Somebody reads the number off every card in the box and types it on the numpad; each entry checks that card off. What is left unchecked at the end of the crate is what is missing.

- A bare number is copy 1: `1234` checks off `1234-1`. A second copy has to be typed as `1234-2`, because nothing on the screen can tell which copy is in the operator's hand.
- Errors are split into the ones that matter at the desk: no such attendee, attendee has no printed badge, attendee has no copy 3 (printed: 1234-1, 1234-2), already checked off (and when).
- Every check-off appears in a running list with an Undo beside it, read back from the database so a reload or a second desk working the same crate loses nothing.
- The screen is deliberately shaped nothing like the dashboard, which is one keystroke away and is also a number field over a keypad: banner, list where the dashboard puts the keypad, keypad shrunk to a touchscreen fallback. An attendee number typed into the wrong screen would otherwise check a card off silently.
- The auto-lock is suspended on this route alone, and the page polls the server every minute to hold the session. Working a crate is minutes of handling cards with no keyboard or mouse, and locking there discards the list the clerk is reading. The screen shows no attendee data and no till.

## What it writes

The same `verified_print_at` the print agent writes, through `PrintJob::markVerified()` with `verification_source = operator` - "a human looked at the card and confirmed it" is exactly what happened. A badge with no print job is stamped directly. The stamp is never cleared by a later reprint; Undo is the only thing that clears it. Who did it goes to the activity log, because `print_jobs.verified_by_id` points at `users` and the person at the desk is a `staff` row.

Counters read "printed" off the fulfillment state, never off `badges.printed_at`: only `ToPrinted` stamps that column and the print pipeline does not go through it, so on live data it is null for every card the agent printed.

## Finding the missing cards

The badge list gains a `Verified` column (hidden by default) and a `Print Verified` ternary filter. Set it to Not verified, add the fulfillment status and the attendee range of the crate just checked, and what is left is the reprint list.

## Tests

13 new cases in `tests/Feature/POS/BadgeVerificationTest.php` covering the copy rule, the stamp path through the print job, duplicates, the error split, Undo, the crate counters and the promoted-card regression. `BadgesTest` parity updated for the new column and filter. Full suite green.