### PR TITLE
Badge verification, reprint guard, select all matching

### DIFF
--- a/app/Console/Commands/ReapPrintJobLeases.php
+++ b/app/Console/Commands/ReapPrintJobLeases.php
@@ -59,7 +59,7 @@ class ReapPrintJobLeases extends Command
             // Mid-card when the agent went quiet. Only a person can see whether
             // the card is in the bin, so the batch stops rather than guessing.
             if ($job->status === PrintJobStatusEnum::Printing) {
-                $job->markFailed(
+                $job->holdForOperator(
                     "Agent stopped responding while this card was printing (lease expired {$age}). "
                     .'The card may already be in the output bin. Check before reprinting.'
                 );

--- a/app/Console/Commands/ReapPrintJobLeases.php
+++ b/app/Console/Commands/ReapPrintJobLeases.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Domain\Printing\Models\PrintJob;
+use App\Enum\PrintJobStatusEnum;
 use Illuminate\Console\Command;
 
 /**
@@ -15,6 +16,19 @@ use Illuminate\Console\Command;
  *
  * Jobs that have been attempted too many times are failed instead of looping,
  * which pauses their batch and puts the problem in front of a human.
+ *
+ * What a lapsed lease means depends on how far the job had got, and the two
+ * cases are not interchangeable:
+ *
+ * - Queued: claimed, but nothing has reached the printer. No card exists, so
+ *   requeueing is free and another agent can pick it up.
+ * - Printing: the artwork went to the spooler. A card may well be sitting in
+ *   the output bin already, and the agent died before it could say so.
+ *   Requeueing that prints a second copy of a card somebody has in their hand.
+ *
+ * Printing therefore stops and asks. Closing the agent mid-batch used to hand
+ * the in-flight card straight back to the queue, so restarting reprinted a card
+ * that had already come out -- up to max-attempts times.
  */
 class ReapPrintJobLeases extends Command
 {
@@ -37,8 +51,23 @@ class ReapPrintJobLeases extends Command
         $requeued = 0;
         $failed = 0;
 
+        $held = 0;
+
         foreach ($expired as $job) {
             $age = $job->lease_expires_at->diffForHumans();
+
+            // Mid-card when the agent went quiet. Only a person can see whether
+            // the card is in the bin, so the batch stops rather than guessing.
+            if ($job->status === PrintJobStatusEnum::Printing) {
+                $job->markFailed(
+                    "Agent stopped responding while this card was printing (lease expired {$age}). "
+                    .'The card may already be in the output bin. Check before reprinting.'
+                );
+                $this->warn("Job #{$job->id}: was mid-print, batch paused for a human.");
+                $held++;
+
+                continue;
+            }
 
             if ($job->attempt_count >= $maxAttempts) {
                 $job->markFailed("Agent stopped responding after {$job->attempt_count} attempts (lease expired {$age}).");
@@ -53,7 +82,7 @@ class ReapPrintJobLeases extends Command
             $requeued++;
         }
 
-        $this->info("Requeued {$requeued}, failed {$failed}.");
+        $this->info("Requeued {$requeued}, failed {$failed}, held for a human {$held}.");
 
         return self::SUCCESS;
     }

--- a/app/Domain/Printing/Models/PrintBatch.php
+++ b/app/Domain/Printing/Models/PrintBatch.php
@@ -434,7 +434,15 @@ class PrintBatch extends Model
     {
         $requeued = 0;
 
-        foreach ($this->printJobs()->where('status', PrintJobStatusEnum::Failed)->get() as $job) {
+        // Deliberately skips jobs whose card may physically exist. Those need a
+        // person to look in the output bin, and requeueing them is exactly the
+        // duplicate this whole path was producing.
+        $failed = $this->printJobs()
+            ->where('status', PrintJobStatusEnum::Failed)
+            ->where('card_may_exist', false)
+            ->get();
+
+        foreach ($failed as $job) {
             if ($job->requeue()) {
                 $requeued++;
             }

--- a/app/Domain/Printing/Models/PrintJob.php
+++ b/app/Domain/Printing/Models/PrintJob.php
@@ -26,7 +26,7 @@ class PrintJob extends Model
     protected $fillable = [
         'printer_id', 'print_batch_id', 'sequence', 'printable_type', 'printable_id',
         'type', 'status', 'file', 'priority', 'retry_count', 'retry_of',
-        'processing_machine_id', 'attempt_count', 'lease_expires_at',
+        'processing_machine_id', 'attempt_count', 'lease_expires_at', 'card_may_exist',
         'completion_source', 'verified_print_at', 'verification_source', 'verified_by_id',
         'firmware_job_id', 'firmware_job_uuid', 'error_message',
         'printed_at', 'queued_at', 'started_at', 'failed_at',
@@ -43,6 +43,7 @@ class PrintJob extends Model
         'started_at' => 'datetime',
         'failed_at' => 'datetime',
         'lease_expires_at' => 'datetime',
+        'card_may_exist' => 'boolean',
         'verified_print_at' => 'datetime',
         'type' => PrintJobTypeEnum::class,
         'status' => PrintJobStatusEnum::class,
@@ -451,6 +452,56 @@ class PrintJob extends Model
         $this->batch?->recalculateCounters();
 
         return $updated;
+    }
+
+    /**
+     * Hold a job whose card may physically exist.
+     *
+     * The agent went quiet mid-print: the artwork reached the spooler and a
+     * card may be in the output bin, but nothing confirmed it. Failing the job
+     * pauses the batch so a person looks, and the flag stops Resume quietly
+     * requeueing it -- which is what printed a second copy of a card somebody
+     * already had in their hand.
+     */
+    public function holdForOperator(string $reason): bool
+    {
+        $this->forceFill(['card_may_exist' => true])->saveQuietly();
+
+        return $this->markFailed($reason);
+    }
+
+    /**
+     * The operator looked in the bin and the card is there.
+     *
+     * Recorded as recovered rather than as a fresh confirmation: the evidence
+     * is a person's eyes, after the fact.
+     */
+    public function confirmCardExists(): bool
+    {
+        $this->forceFill(['card_may_exist' => false])->saveQuietly();
+
+        if ($this->status === PrintJobStatusEnum::Failed) {
+            $this->transitionTo(PrintJobStatusEnum::Retrying);
+            $this->transitionTo(PrintJobStatusEnum::Queued);
+            $this->transitionTo(PrintJobStatusEnum::Printing);
+        }
+
+        $done = $this->markPrinted(PrintCompletionSourceEnum::Recovered);
+
+        $this->batch?->recalculateCounters();
+        $this->batch?->completeIfFinished();
+
+        return $done;
+    }
+
+    /**
+     * The operator looked and there is no card. Print it after all.
+     */
+    public function requeueDespiteCard(): bool
+    {
+        $this->forceFill(['card_may_exist' => false])->saveQuietly();
+
+        return $this->requeue();
     }
 
     /**

--- a/app/Enum/PrintCompletionSourceEnum.php
+++ b/app/Enum/PrintCompletionSourceEnum.php
@@ -27,6 +27,17 @@ enum PrintCompletionSourceEnum: string
     /** A human declared it done, typically after clearing a fault by hand. */
     case Operator = 'operator';
 
+    /**
+     * The agent's own records said this card had already printed here.
+     *
+     * Written when a job comes back after its lease lapsed -- the agent was
+     * closed or the host rebooted mid-run -- and the station's local store
+     * shows the card was already confirmed. The evidence is real but second
+     * hand, so it is recorded as its own source rather than dressed up as a
+     * fresh firmware confirmation.
+     */
+    case Recovered = 'recovered';
+
     public function isAuthoritative(): bool
     {
         return $this === self::Firmware;
@@ -38,6 +49,7 @@ enum PrintCompletionSourceEnum: string
             self::Firmware => 'Confirmed by printer',
             self::SpoolerOnly => 'Spooler only',
             self::Operator => 'Marked done by staff',
+            self::Recovered => 'Recovered from the agent after a restart',
         };
     }
 }

--- a/app/Http/Controllers/Manage/BadgeController.php
+++ b/app/Http/Controllers/Manage/BadgeController.php
@@ -306,6 +306,55 @@ class BadgeController extends Controller
      */
     private function table(Request $request, EventScope $scope): array
     {
+        return $this->tableBuilder($scope)->toArray($request);
+    }
+
+    /**
+     * Every badge the given filters, search and event scope match, capped.
+     *
+     * The bulk print's "select all matching" resolves through here rather than through a
+     * list of ids from the browser: the page holds twenty-five rows and the operator
+     * asked for the thousand behind them. Built from the same Table as the list, so the
+     * set queued is by construction the set that was on screen - a second query written
+     * to look like the list's is a second query that can drift from it.
+     *
+     * @return array<int, int|string>
+     */
+    public function matchingIds(Request $request, EventScope $scope, int $limit): array
+    {
+        Gate::authorize('viewAny', Badge::class);
+
+        return $this->tableBuilder($scope)->matchingIds($this->listRequest($request), $limit);
+    }
+
+    /**
+     * The bulk POST's `query` field, read back as the GET the list was drawn by.
+     *
+     * The client forwards the list's own query string verbatim instead of rebuilding
+     * `filter[...]` as nested form data: it is the exact string that produced the page, so
+     * the set queued cannot drift from the set on screen, and it is parsed here by the
+     * same rules that read it off a GET. Only the narrowing keys are read - Table ignores
+     * sort and page when resolving a set - and nothing in it can widen the event scope,
+     * which is session state and not in the query at all.
+     */
+    private function listRequest(Request $request): Request
+    {
+        $query = (string) $request->input('query', '');
+
+        if ($query === '') {
+            return $request;
+        }
+
+        parse_str($query, $params);
+
+        return Request::create('/', 'GET', is_array($params) ? $params : []);
+    }
+
+    /**
+     * The list table, before it is asked for a page or for a set of ids.
+     */
+    private function tableBuilder(EventScope $scope): Table
+    {
         return Table::make($this->query($scope))
             ->name('badges')
             ->columns($this->columns())
@@ -341,18 +390,23 @@ class BadgeController extends Controller
             // deliberately no bulk delete, no export and no dissociate, because
             // the old badge list passes bulkActions() an explicit array.
             //
-            // The selection keeps ->selectCurrentPageOnly() semantics for free: DataTable
-            // derives it from the current page's rows and prunes it on every reload, so it
-            // cannot cross a page. That cap is deliberate, not accidental, and
-            // the bulk print inherits it.
+            // The tick boxes keep ->selectCurrentPageOnly() semantics for free: DataTable
+            // derives the selection from the current page's rows and prunes it on every
+            // reload, so ticking cannot cross a page.
+            //
+            // The bulk print is the one action that may go past it, through
+            // `all: true` rather than through the boxes: a print run is the whole of what
+            // the filter matches - every unprinted badge approved since the last run - and
+            // ticking a thousand cards twenty-five at a time is not a workflow. The
+            // fulfillment write stays page-only; it bypasses the state machine, and doing
+            // that to an unseen thousand rows is a different order of mistake.
             ->bulkActions(array_values(array_filter([
                 BadgePrintController::bulkAction(),
                 self::bulkStatusAction(),
             ])))
             // ListBadges offers a CreateAction labelled `New badge`. It is not ported: the
             // page it opens has never been able to save.
-            ->pageActions([])
-            ->toArray($request);
+            ->pageActions([]);
     }
 
     /**

--- a/app/Http/Controllers/Manage/BadgeController.php
+++ b/app/Http/Controllers/Manage/BadgeController.php
@@ -393,11 +393,13 @@ class BadgeController extends Controller
     }
 
     /**
-     * The audit's fourteen columns, in order, with the old panel's own labels verbatim.
+     * The audit's fourteen columns, in order, with the old panel's own labels verbatim,
+     * followed by Verified, which is not the audit's.
      *
      * Five are hidden by default, which is every `isToggledHiddenByDefault: true` flag
      * the old badge list carries: extra_copy, total, created_at, printed_at, picked_up_at
-     *.
+     *. Verified is hidden too: it is read with the print_verified filter when a crate is
+     * being reconciled, and is noise the rest of the time.
      *
      * @return array<int, Column>
      */
@@ -441,6 +443,12 @@ class BadgeController extends Controller
             Column::datetime('picked_up_at', 'Picked Up')
                 ->toggleable(hiddenByDefault: true)
                 ->fallback('Not picked up'),
+            // The card was seen: either the print agent's camera saw it come out,
+            // or somebody typed its number off the physical card at the desk. What
+            // is printed and never verified is what has to be reprinted.
+            Column::datetime('verified_print_at', 'Verified')
+                ->toggleable(hiddenByDefault: true)
+                ->fallback('Not verified'),
         ];
     }
 
@@ -481,6 +489,7 @@ class BadgeController extends Controller
             'created_at' => $this->datetime($badge->created_at, self::DATE_FORMAT),
             'printed_at' => $this->datetime($badge->printed_at),
             'picked_up_at' => $this->datetime($badge->picked_up_at),
+            'verified_print_at' => $this->datetime($badge->verified_print_at),
         ];
     }
 
@@ -527,7 +536,8 @@ class BadgeController extends Controller
     }
 
     /**
-     * The audit's four filters.
+     * The audit's four filters, the two approval bounds added with the print cutoff, and
+     * the verification filter added with the POS check-off screen.
      *
      * @return array<int, Filter>
      */
@@ -576,6 +586,19 @@ class BadgeController extends Controller
             Filter::datetime('approved_until', 'Approved until')
                 ->chipLabel('Approved before')
                 ->apply(fn (Builder $query, string $value) => $this->applyApprovedBound($query, '<=', $value)),
+
+            // The reprint list. Set this to "Not verified", the fulfillment status to
+            // the printed states and the attendee range to the crate that was just
+            // checked off at the desk, and what is left is the cards that were
+            // printed and never turned up. See BadgeVerificationController.
+            Filter::ternary('print_verified', 'Print Verified')
+                ->placeholder('Verified or not')
+                ->trueLabel('Verified')
+                ->falseLabel('Not verified')
+                ->chipLabel('Verification')
+                ->apply(fn (Builder $query, string $value) => $value === '1'
+                    ? $query->whereNotNull('badges.verified_print_at')
+                    : $query->whereNull('badges.verified_print_at')),
         ];
     }
 

--- a/app/Http/Controllers/Manage/BadgePrintController.php
+++ b/app/Http/Controllers/Manage/BadgePrintController.php
@@ -13,6 +13,7 @@ use App\Http\Requests\Manage\BadgePrintRequest;
 use App\Models\Badge\Badge;
 use App\Models\Badge\State_Fulfillment\Processing;
 use App\Support\Manage\Action;
+use App\Support\Manage\EventScope;
 use App\Support\Manage\Status;
 use App\Support\Manage\Toast;
 use Carbon\Carbon;
@@ -87,6 +88,16 @@ class BadgePrintController extends Controller
     private const NOTHING_QUEUED = 'Nothing was queued';
 
     /**
+     * How many badges one "select all matching" may queue.
+     *
+     * High enough that no real filter reaches it - the whole convention is a few thousand
+     * cards and a run is a slice of that - and low enough that a filter cleared by
+     * accident cannot commit the entire table to a printer in one click. When it bites,
+     * the toast says so; see bulk().
+     */
+    private const SELECT_ALL_CAP = 2000;
+
+    /**
      * `printBadge`, the row action.
      *
      * The request does not move the badge to Processing, and must not. That transition is
@@ -135,16 +146,31 @@ class BadgePrintController extends Controller
     /**
      * `printBadgeBulk`, the bulk action.
      *
-     * The selection can never cross a page, which is `->selectCurrentPageOnly()` and a
-     * deliberate operational cap the panel keeps.
+     * Two selections reach here. The tick boxes send `ids` and cannot cross a page, which
+     * is `->selectCurrentPageOnly()` and a cap the panel keeps. `all: true` sends no ids
+     * at all and means "every badge the list's current filter matches", resolved by
+     * BadgeController against the same Table the page was drawn from, so what is queued is
+     * by construction what the operator was looking at. That is the run a print session
+     * actually is: everything approved since the last cutoff, not twenty-five of it.
+     *
+     * `all` is capped at SELECT_ALL_CAP and the operator is told when the cap bit. A run
+     * silently trimmed to the cap would report as the whole of the filter and the
+     * remainder would be found missing at the desk, which is precisely the failure the
+     * verification screen exists to catch.
      *
      * The badges are read in a single query ordered by id, only so the request is
      * deterministic. The print order is `PrintBatch::build()`'s and nothing here competes
      * with it.
      */
-    public function bulk(BadgePrintRequest $request): RedirectResponse
+    public function bulk(BadgePrintRequest $request, BadgeController $list, EventScope $scope): RedirectResponse
     {
-        $badges = Badge::whereIn('id', $request->validated('ids'))
+        $selectAll = (bool) $request->validated('all', false);
+
+        $ids = $selectAll
+            ? $list->matchingIds($request, $scope, self::SELECT_ALL_CAP)
+            : $request->validated('ids', []);
+
+        $badges = Badge::whereIn('id', $ids)
             ->orderBy('id')
             ->get();
 
@@ -165,7 +191,9 @@ class BadgePrintController extends Controller
 
         Toast::flashSuccess(
             $badges->count() === 1 ? 'Badge queued for printing' : 'Badges queued for printing',
-            $this->queuedBody($batch),
+            $this->queuedBody($batch).($selectAll && count($ids) >= self::SELECT_ALL_CAP
+                ? ' Capped at '.self::SELECT_ALL_CAP.' badges: narrow the filter and run it again for the rest.'
+                : ''),
         );
 
         return $this->backWithCutoff($badges);
@@ -307,6 +335,9 @@ class BadgePrintController extends Controller
         return Action::post('printBadgeBulk', self::BULK_LABEL, route('admin.badges.bulk.print'))
             ->icon('printer')
             ->tone(Status::WARN)
+            // The one bulk action that understands "everything the filter matches"; the
+            // client offers that affordance only for actions carrying this flag.
+            ->selectAll()
             ->confirm(self::BULK_HEADING, self::BULK_DESCRIPTION)
             ->fields([
                 [

--- a/app/Http/Controllers/POS/BadgeVerificationController.php
+++ b/app/Http/Controllers/POS/BadgeVerificationController.php
@@ -32,6 +32,13 @@ use Inertia\Inertia;
 class BadgeVerificationController extends Controller
 {
     /**
+     * The fulfillment states a physical card exists in.
+     *
+     * @var array<int, string>
+     */
+    private const PRINTED_STATES = ['printed', 'ready_for_pickup', 'picked_up'];
+
+    /**
      * The screen: counters for the crate, and the tail of the check-off list.
      *
      * The list is read back from the database rather than kept in the browser,
@@ -58,7 +65,7 @@ class BadgeVerificationController extends Controller
                 'min' => $machine?->badge_range_min,
                 'max' => $machine?->badge_range_max,
             ],
-            'recent' => $this->recent($event, $machine),
+            'recent' => $this->recent($event),
             // The verdict on the number just typed. It rides the session rather
             // than the shared flash bag, which only carries success/error strings
             // and is read by the toast layer; this one is a small structure the
@@ -258,15 +265,19 @@ class BadgeVerificationController extends Controller
     /**
      * Printed cards of this event, narrowed to the crate this desk holds.
      *
-     * Printed means the card exists: `printed_at` is stamped by the fulfillment
-     * transition that also allocates `custom_id`, so it is the same population
-     * the crate was filled from.
+     * "Printed" is the fulfillment state, not `printed_at`. Only `ToPrinted`
+     * stamps that column, and the print pipeline does not go through it: a job
+     * finishing calls `promoteBadgeToReadyForPickup()`, which transitions
+     * straight to ReadyForPickup. Filtering on the timestamp counted zero cards
+     * on live data while the crate was full of them.
      */
     private function printedBadges(Event $event, ?Machine $machine): Builder
     {
         $query = Badge::whereHas('fursuit', fn (Builder $q) => $q->where('event_id', $event->id))
-            ->whereNotNull('badges.printed_at')
-            ->whereNotNull('badges.custom_id');
+            ->whereNotNull('badges.custom_id')
+            ->where(fn (Builder $q) => $q
+                ->whereIn('badges.status_fulfillment', self::PRINTED_STATES)
+                ->orWhereNotNull('badges.printed_at'));
 
         $this->applyBadgeRange($query, $event, $machine);
 
@@ -298,9 +309,14 @@ class BadgeVerificationController extends Controller
     /**
      * @return array<int, array<string, mixed>>
      */
-    private function recent(Event $event, ?Machine $machine): array
+    private function recent(Event $event): array
     {
-        return $this->printedBadges($event, $machine)
+        // Every checked-off card of this event, not only the ones the counters
+        // count, and not narrowed to this desk's crate. Anything typed into the
+        // field can be checked off, so anything typed into the field has to
+        // appear here - a screen that answers "checked off" and then shows an
+        // empty list reads as the check-off having failed.
+        return Badge::whereHas('fursuit', fn (Builder $q) => $q->where('event_id', $event->id))
             ->whereNotNull('badges.verified_print_at')
             ->with(['fursuit.user'])
             ->orderByDesc('badges.verified_print_at')

--- a/app/Http/Controllers/POS/BadgeVerificationController.php
+++ b/app/Http/Controllers/POS/BadgeVerificationController.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace App\Http\Controllers\POS;
+
+use App\Domain\Printing\Models\PrintJob;
+use App\Enum\PrintJobStatusEnum;
+use App\Enum\PrintVerificationSourceEnum;
+use App\Http\Controllers\Controller;
+use App\Models\Badge\Badge;
+use App\Models\Event;
+use App\Models\EventUser;
+use App\Models\Machine;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+
+/**
+ * Checking a printed card off against the stack in front of you.
+ *
+ * The desk holds a crate of finished cards. Somebody reads the number off every
+ * card and types it, the card is verified, and whatever is still unverified at
+ * the end of the crate is what never came out of the printer and has to be
+ * reprinted. That is the whole feature: a numpad, a running list, and an undo.
+ *
+ * It writes the same `verified_print_at` the print agent writes, with
+ * `verification_source = operator`, because "a human looked at the card and
+ * confirmed it" is exactly what happened. A card verified here is never
+ * un-verified by a later reprint - the stamp says the card was seen once, and
+ * the admin list is filtered on it to find the ones that never were.
+ */
+class BadgeVerificationController extends Controller
+{
+    /**
+     * The screen: counters for the crate, and the tail of the check-off list.
+     *
+     * The list is read back from the database rather than kept in the browser,
+     * so it survives a lock, a reload and a second clerk working the same crate.
+     */
+    public function index(Request $request)
+    {
+        $event = Event::getActiveEvent();
+        $machine = auth('machine')->user();
+
+        if (! $event) {
+            return redirect()->route('pos.dashboard')->with('error', 'No current event found');
+        }
+
+        $printed = $this->printedBadges($event, $machine);
+
+        return Inertia::render('POS/Verification/Index', [
+            'stats' => [
+                'printed' => (clone $printed)->count(),
+                'verified' => (clone $printed)->whereNotNull('badges.verified_print_at')->count(),
+                'missing' => (clone $printed)->whereNull('badges.verified_print_at')->count(),
+            ],
+            'badgeRange' => [
+                'min' => $machine?->badge_range_min,
+                'max' => $machine?->badge_range_max,
+            ],
+            'recent' => $this->recent($event, $machine),
+            // The verdict on the number just typed. It rides the session rather
+            // than the shared flash bag, which only carries success/error strings
+            // and is read by the toast layer; this one is a small structure the
+            // page renders itself.
+            'result' => fn () => $request->session()->get('verification'),
+        ]);
+    }
+
+    /**
+     * Check one card off.
+     *
+     * A bare attendee number means their first badge, because that is what all
+     * but a handful of them have: `1234` is `1234-1`. A second copy has to be
+     * typed in full as `1234-2`, since guessing which copy is in your hand is
+     * exactly the mistake this screen exists to catch.
+     */
+    public function store(Request $request)
+    {
+        $event = Event::getActiveEvent();
+
+        if (! $event) {
+            return back()->with('error', 'No current event found');
+        }
+
+        $customId = $this->normalizeBadgeId((string) $request->input('badge_id', ''));
+
+        if ($customId === null) {
+            return back()->with('verification', [
+                'status' => 'error',
+                'message' => 'Not a badge number. Type 1234 or 1234-2.',
+                'input' => trim((string) $request->input('badge_id', '')),
+            ]);
+        }
+
+        $badge = Badge::whereHas('fursuit', fn (Builder $q) => $q->where('event_id', $event->id))
+            ->with(['fursuit.user'])
+            ->where('custom_id', $customId)
+            ->first();
+
+        if (! $badge) {
+            return back()->with('verification', [
+                'status' => 'error',
+                'message' => $this->missingBadgeReason($event, $customId),
+                'input' => $customId,
+            ]);
+        }
+
+        if ($badge->verified_print_at !== null) {
+            return back()->with('verification', [
+                'status' => 'duplicate',
+                'message' => $customId.' was already checked off '.$badge->verified_print_at->diffForHumans().'.',
+                'input' => $customId,
+                'badge' => $this->badgeRow($badge),
+            ]);
+        }
+
+        $this->verify($badge);
+
+        return back()->with('verification', [
+            'status' => 'ok',
+            'message' => $customId.' checked off.',
+            'input' => $customId,
+            'badge' => $this->badgeRow($badge->fresh(['fursuit.user'])),
+        ]);
+    }
+
+    /**
+     * Undo one check-off, for the card typed as `1234-1` that was `1234-2`.
+     *
+     * Clears the stamp on the badge and on its print jobs, so the card falls
+     * back into the unverified list and the batch counters agree with it again.
+     */
+    public function revert(Badge $badge)
+    {
+        if ($badge->verified_print_at === null) {
+            return back()->with('verification', [
+                'status' => 'error',
+                'message' => ($badge->custom_id ?? 'That badge').' was not checked off.',
+                'input' => $badge->custom_id,
+            ]);
+        }
+
+        DB::transaction(function () use ($badge) {
+            $badge->printJobs()
+                ->whereNotNull('verified_print_at')
+                ->get()
+                ->each(function (PrintJob $job) {
+                    $job->update([
+                        'verified_print_at' => null,
+                        'verification_source' => null,
+                        'verified_by_id' => null,
+                    ]);
+
+                    $job->batch?->recalculateCounters();
+                });
+
+            $badge->forceFill(['verified_print_at' => null])->saveQuietly();
+
+            activity()
+                ->performedOn($badge)
+                ->withProperties(['staff' => auth('machine-user')->user()?->name])
+                ->log('Badge check-off reverted at the desk');
+        });
+
+        return back()->with('verification', [
+            'status' => 'reverted',
+            'message' => ($badge->custom_id ?? 'Badge').' put back on the missing list.',
+            'input' => $badge->custom_id,
+        ]);
+    }
+
+    /**
+     * Stamp the card, through the print job where there is one.
+     *
+     * `PrintJob::markVerified()` is what the agent calls, and it mirrors the
+     * stamp onto the badge and recounts the batch. A badge printed before print
+     * jobs existed, or whose job was pruned, still has to be checkable off, so
+     * the badge is stamped directly in that case.
+     */
+    private function verify(Badge $badge): void
+    {
+        DB::transaction(function () use ($badge) {
+            $job = $badge->printJobs()
+                ->where('status', PrintJobStatusEnum::Printed)
+                ->orderByDesc('printed_at')
+                ->first()
+                ?? $badge->printJobs()->orderByDesc('id')->first();
+
+            if ($job) {
+                // No `verified_by`: that column points at `users`, and the person
+                // at the desk is a `staff` row. The activity log below carries who.
+                $job->markVerified(PrintVerificationSourceEnum::Operator);
+            } else {
+                $badge->forceFill(['verified_print_at' => now()])->saveQuietly();
+            }
+
+            activity()
+                ->performedOn($badge)
+                ->withProperties(['staff' => auth('machine-user')->user()?->name])
+                ->log('Badge checked off at the desk');
+        });
+    }
+
+    /**
+     * `1234` -> `1234-1`, `1234-2` -> `1234-2`, anything else -> null.
+     *
+     * Numpad and scanner both emit stray characters, and the numpad's minus is
+     * the only separator on the keypad, so a dash is the one non-digit allowed.
+     */
+    private function normalizeBadgeId(string $raw): ?string
+    {
+        $value = trim(str_replace(['–', '—', ' '], ['-', '-', ''], $raw));
+
+        if (preg_match('/^\d+$/', $value)) {
+            return $value.'-1';
+        }
+
+        if (preg_match('/^(\d+)-(\d+)$/', $value, $matches)) {
+            return $matches[1].'-'.$matches[2];
+        }
+
+        return null;
+    }
+
+    /**
+     * Why a typed number found nothing, phrased for somebody holding a card.
+     *
+     * "No such badge" is useless at the desk: the interesting split is between a
+     * number nobody at this event has and an attendee whose card has not been
+     * printed, because only the second one is a card that should be in the crate.
+     */
+    private function missingBadgeReason(Event $event, string $customId): string
+    {
+        [$attendeeId, $copy] = explode('-', $customId, 2);
+
+        $attendeeExists = EventUser::where('event_id', $event->id)
+            ->where('attendee_id', $attendeeId)
+            ->exists();
+
+        if (! $attendeeExists) {
+            return 'No attendee '.$attendeeId.' at this event.';
+        }
+
+        $printedCopies = Badge::whereHas('fursuit', fn (Builder $q) => $q->where('event_id', $event->id))
+            ->where('custom_id', 'like', $attendeeId.'-%')
+            ->pluck('custom_id')
+            ->sort()
+            ->values();
+
+        if ($printedCopies->isEmpty()) {
+            return 'Attendee '.$attendeeId.' has no printed badge. Card should not be in the box.';
+        }
+
+        return 'Attendee '.$attendeeId.' has no copy '.$copy.'. Printed: '.$printedCopies->implode(', ').'.';
+    }
+
+    /**
+     * Printed cards of this event, narrowed to the crate this desk holds.
+     *
+     * Printed means the card exists: `printed_at` is stamped by the fulfillment
+     * transition that also allocates `custom_id`, so it is the same population
+     * the crate was filled from.
+     */
+    private function printedBadges(Event $event, ?Machine $machine): Builder
+    {
+        $query = Badge::whereHas('fursuit', fn (Builder $q) => $q->where('event_id', $event->id))
+            ->whereNotNull('badges.printed_at')
+            ->whereNotNull('badges.custom_id');
+
+        $this->applyBadgeRange($query, $event, $machine);
+
+        return $query;
+    }
+
+    /**
+     * The crate this desk holds, same rule as the dashboard counter.
+     */
+    private function applyBadgeRange(Builder $query, Event $event, ?Machine $machine): void
+    {
+        if (! $machine || ! $machine->hasBadgeRange()) {
+            return;
+        }
+
+        $query->whereHas('fursuit.user.eventUsers', function ($q) use ($event, $machine) {
+            $q->where('event_id', $event->id);
+
+            if ($machine->badge_range_min !== null) {
+                $q->whereRaw('CAST(attendee_id AS SIGNED) >= ?', [$machine->badge_range_min]);
+            }
+
+            if ($machine->badge_range_max !== null) {
+                $q->whereRaw('CAST(attendee_id AS SIGNED) <= ?', [$machine->badge_range_max]);
+            }
+        });
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function recent(Event $event, ?Machine $machine): array
+    {
+        return $this->printedBadges($event, $machine)
+            ->whereNotNull('badges.verified_print_at')
+            ->with(['fursuit.user'])
+            ->orderByDesc('badges.verified_print_at')
+            ->orderByDesc('badges.id')
+            ->limit(30)
+            ->get()
+            ->map(fn (Badge $badge) => $this->badgeRow($badge))
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function badgeRow(Badge $badge): array
+    {
+        return [
+            'id' => $badge->id,
+            'custom_id' => $badge->custom_id,
+            'fursuit_name' => $badge->fursuit?->name,
+            'owner_name' => $badge->fursuit?->user?->name,
+            'verified_at' => $badge->verified_print_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Controllers/PrintAgent/AgentJobController.php
+++ b/app/Http/Controllers/PrintAgent/AgentJobController.php
@@ -112,7 +112,7 @@ class AgentJobController extends AgentController
     public function printed(Request $request, int $job): JsonResponse
     {
         $data = $request->validate([
-            'completion_source' => ['required', 'string', 'in:firmware,spooler_only,operator'],
+            'completion_source' => ['required', 'string', 'in:firmware,spooler_only,operator,recovered'],
             'firmware_job_id' => 'nullable|string|max:64',
             'firmware_job_uuid' => 'nullable|string|max:64',
         ]);

--- a/app/Http/Requests/Manage/BadgePrintRequest.php
+++ b/app/Http/Requests/Manage/BadgePrintRequest.php
@@ -42,8 +42,17 @@ class BadgePrintRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'ids' => ['required', 'array'],
+            // Either an explicit selection, or `all` - "every badge the list's current
+            // filter matches", which the server resolves. Never both: `ids` is what the
+            // tick boxes send and is ignored when `all` is set.
+            'all' => ['sometimes', 'boolean'],
+            'ids' => ['required_without:all', 'array'],
             'ids.*' => ['integer'],
+            // The list's own query string, forwarded verbatim by the bulk bar and parsed
+            // back into filters by BadgeController. Only read when `all` is set.
+            // Nullable: an unfiltered list forwards an empty string, which the framework
+            // has already converted to null by the time the rules run.
+            'query' => ['sometimes', 'nullable', 'string', 'max:2000'],
             'printer_id' => ['required', 'integer', Rule::in(BadgePrintController::printerIds())],
         ];
     }
@@ -54,6 +63,7 @@ class BadgePrintRequest extends FormRequest
     public function messages(): array
     {
         return [
+            'ids.required_without' => 'Select the badges to print, or select everything the filter matches.',
             'printer_id.required' => 'Select a printer to send these badges to.',
             'printer_id.in' => 'That printer is not an active badge printer.',
         ];

--- a/app/Support/Manage/Action.php
+++ b/app/Support/Manage/Action.php
@@ -39,6 +39,8 @@ final class Action implements Arrayable
 
     private bool $newTab = false;
 
+    private bool $selectAll = false;
+
     private function __construct(
         public readonly string $name,
         public readonly string $label,
@@ -139,6 +141,22 @@ final class Action implements Arrayable
     }
 
     /**
+     * This action understands `all: true` - "every record the current filter matches",
+     * resolved server side - as well as a list of ids.
+     *
+     * Opt-in per action, and the client only offers the affordance for actions carrying
+     * this flag. An endpoint that reads `ids` and ignores `all` would otherwise answer a
+     * "select all 1,204" by acting on the 25 rows that happen to be on screen, which is
+     * the one outcome worse than not offering it.
+     */
+    public function selectAll(bool $selectAll = true): self
+    {
+        $this->selectAll = $selectAll;
+
+        return $this;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function toArray(): array
@@ -154,6 +172,7 @@ final class Action implements Arrayable
             'fields' => $this->fields === [] ? null : $this->fields,
             'disabledReason' => $this->disabledReason,
             'newTab' => $this->newTab,
+            'selectAll' => $this->selectAll,
         ];
     }
 }

--- a/app/Support/Manage/Table.php
+++ b/app/Support/Manage/Table.php
@@ -244,6 +244,36 @@ final class Table
     }
 
     /**
+     * The keys of every record the current tab, filters and search match, ignoring
+     * pagination and sort.
+     *
+     * This is what "select all matching" resolves to. It is deliberately not the client's
+     * job: the browser holds one page of ids, and a selection that means "everything the
+     * filter matches" can only be answered by the same narrowing that produced the page.
+     * Sort is skipped because a set has no order, and the print pipeline imposes its own.
+     *
+     * `$limit` is a real cap, not a guess: the caller is expected to compare what comes
+     * back against it and tell the operator when the run was trimmed, because a silently
+     * truncated "all" reads as "all".
+     *
+     * The request is a POST here, so `rememberReturnUrl()` is not called and the list URL
+     * this action came from stays remembered.
+     *
+     * @return array<int, int|string>
+     */
+    public function matchingIds(Request $request, int $limit): array
+    {
+        $this->resolveTab($request)?->applyTo($this->query);
+        $this->applyFilters($this->resolveFilterValues($request));
+        $this->applySearch(trim((string) $request->input('search', '')));
+
+        return $this->query
+            ->limit($limit)
+            ->pluck($this->query->getModel()->getQualifiedKeyName())
+            ->all();
+    }
+
+    /**
      * Remembers the list URL, query string and all, so a save can come back to it.
      *
      * Tab, filters, search, sort and page live entirely in the URL, so a controller that

--- a/database/migrations/2026_08_08_180000_add_card_may_exist_to_print_jobs_table.php
+++ b/database/migrations/2026_08_08_180000_add_card_may_exist_to_print_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Support\Migrations\SchemaGuard;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Mark the jobs where a card may physically exist but nothing recorded it.
+ *
+ * Happens when an agent dies mid-print: the artwork reached the spooler, a card
+ * may be in the output bin, and the confirmation never arrived. The job is
+ * failed so a human looks at it, but "failed" alone is indistinguishable from a
+ * card that never printed -- and Resume requeues those, which printed a second
+ * copy of a card somebody already had in their hand.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('print_jobs', function (Blueprint $table) {
+            if (SchemaGuard::missingColumn('print_jobs', 'card_may_exist')) {
+                $table->boolean('card_may_exist')->default(false)->after('completion_source');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('print_jobs', function (Blueprint $table) {
+            if (SchemaGuard::hasColumn('print_jobs', 'card_may_exist')) {
+                $table->dropColumn('card_may_exist');
+            }
+        });
+    }
+};

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -175,6 +175,18 @@ Two rules on that screen, both learned from cards going out twice:
 - The stamp is never cleared by a later reprint. It records that the card was seen once. The undo
   button is the only thing that clears it, for the number typed off the wrong card.
 
+The counters read "printed" off the fulfillment state, never off `badges.printed_at`. Only the
+`ToPrinted` transition stamps that column and the print pipeline does not go through it - a finished
+job calls `promoteBadgeToReadyForPickup()` - so on live data the timestamp is null for every card the
+agent printed. The screen counted zero cards against a full crate until that was fixed. The list
+below the counters is deliberately wider than them: it shows every card checked off at this event,
+including ones outside the desk's crate, because anything the field accepts has to appear there.
+
+The screen is also shaped nothing like the dashboard, which is one keystroke away and is also a
+number field over a keypad. An attendee number typed into the wrong one would check a card off
+without anybody noticing, so this one wears a banner, puts the list where the dashboard puts the
+keypad, and shrinks the keypad to a touchscreen fallback.
+
 The auto-lock is suspended on that route alone. Working a crate is minutes of handling cards with no
 keyboard or mouse in between, and locking there discards the list of what was already checked; the
 page polls the server every minute to hold the session instead. The screen shows no attendee data

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -42,6 +42,18 @@ costs nothing but trouble. See `App\Badges\ImagePreparer`.
 
 ## Starting a run
 
+**What goes into a run.** The badge list's tick boxes cannot cross a page, which is deliberate for
+every bulk action in `/admin`. The print run is the one exception: with the page fully ticked, the
+bulk bar offers **Select all N matching the filter**, and the action then posts `all: true` plus the
+list's own query string instead of a list of ids. `BadgeController::matchingIds()` re-narrows through
+the same `Table` that drew the page, so what is queued is by construction what was on screen. The
+event scope rides in the session and cannot be widened by the forwarded query.
+
+A run started that way is capped at 2000 badges and the toast says so when the cap bites, because a
+run silently trimmed to a cap reports as the whole filter and the remainder is only discovered
+missing at the desk. Only actions declaring `Action::selectAll()` are offered past the page: the bulk
+fulfillment write bypasses the state machine and stays page-only.
+
 Pressing Print does not print, and does not render. The request opens an empty `Draft` batch and
 dispatches `PrepareBadgePrintBatchJob` on the `badge-render` queue; everything expensive happens
 there. The operator gets the batch back immediately and watches it turn from preparing to ready.

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -159,6 +159,27 @@ different questions answered by different calls. `verified_print_at` and `verifi
 No camera images are ever uploaded to the server. Only the verdict. (The optional Telegram channel
 posts photos to a chat, which is a separate, opt-in channel; see below.)
 
+**The desk check-off** is the third way a card gets verified, and the only one that proves the card
+is in the building. `/pos/verification` (F8) is a numpad, a running list and an undo: somebody reads
+the number off every card in the crate and types it, and each entry stamps `verified_print_at`
+through `PrintJob::markVerified()` with `verification_source = operator`, exactly as the agent's own
+operator verdict does. What is left over at the end of the crate - printed, never checked off - is
+what never came out of the printer, and is found in `/admin` by filtering the badge list on
+**Print Verified = Not verified** plus the fulfillment status and the attendee range that crate
+covers.
+
+Two rules on that screen, both learned from cards going out twice:
+
+- A bare number is copy 1. `1234` checks off `1234-1`; a second copy has to be typed as `1234-2`,
+  because nothing on the screen can tell which copy is in the operator's hand.
+- The stamp is never cleared by a later reprint. It records that the card was seen once. The undo
+  button is the only thing that clears it, for the number typed off the wrong card.
+
+The auto-lock is suspended on that route alone. Working a crate is minutes of handling cards with no
+keyboard or mouse in between, and locking there discards the list of what was already checked; the
+page polls the server every minute to hold the session instead. The screen shows no attendee data
+and no till, so the lock protects nothing there.
+
 ## Printer condition
 
 The agent polls SNMP and reduces the reading to a `PrinterConditionEnum` case, which the POS shows

--- a/print-agent/agent/api.py
+++ b/print-agent/agent/api.py
@@ -43,6 +43,11 @@ COMPLETION_FIRMWARE = "firmware"
 COMPLETION_SPOOLER_ONLY = "spooler_only"
 COMPLETION_OPERATOR = "operator"
 
+# The agent's own records showed the card had already printed here, on a job the
+# server handed back after a lease lapsed. Second-hand evidence, so it is named
+# rather than passed off as a fresh firmware confirmation.
+COMPLETION_RECOVERED = "recovered"
+
 # Accepted by POST /jobs/{job}/verify. See PrintVerificationSourceEnum.
 VERIFY_CAMERA = "camera"
 VERIFY_OPERATOR = "operator"

--- a/print-agent/agent/worker.py
+++ b/print-agent/agent/worker.py
@@ -61,6 +61,7 @@ from typing import Any, Callable, Dict, List, NamedTuple, Optional
 from .api import (
     COMPLETION_FIRMWARE,
     COMPLETION_OPERATOR,
+    COMPLETION_RECOVERED,
     COMPLETION_SPOOLER_ONLY,
     VERIFY_CAMERA,
     VERIFY_OPERATOR,
@@ -686,6 +687,54 @@ class _BaseWorker:
     # Odds and ends
     # ------------------------------------------------------------------
 
+    def _already_printed(self, job_id: int) -> Optional[Outcome]:
+        """Refuse to print a card this station has already produced.
+
+        A job only comes back after its lease lapsed, which happens when the
+        agent was closed or the host rebooted mid-run. The server cannot know
+        whether a card came out -- but this station can, because it wrote down
+        how far the job got before it died.
+
+        Only `reported` and `done` count as evidence. Both are written after the
+        printer confirmed the card. `printing` is set before the artwork is
+        spooled, so it proves an attempt, not a card, and that ambiguous case is
+        left to the operator through the usual reprint question.
+
+        Returns an Outcome to hand straight back, or None to print normally.
+        """
+        try:
+            record = self.store.job(job_id)
+        except Exception:  # noqa: BLE001 - an unreadable store cannot veto a print
+            return None
+
+        if not record:
+            return None
+
+        status = (record.get("status") or "").lower()
+
+        if status not in (JOB_REPORTED, JOB_DONE):
+            return None
+
+        card = record.get("card_number") or str(job_id)
+        detail = ("Card %s already printed here; telling the server rather than "
+                  "printing it twice" % card)
+
+        self._log(detail)
+        self._progress(STEP_REPORT, DONE, "already printed")
+
+        # The server thinks this is still outstanding, so the confirmation it
+        # never received goes out again. Through the outbox, so a server that is
+        # still unreachable does not lose it a second time.
+        self._deliver(
+            OUTBOX_PRINTED,
+            {"job_id": job_id, "completion_source": COMPLETION_RECOVERED},
+            lambda: self.api.mark_printed(job_id, completion_source=COMPLETION_RECOVERED),
+        )
+
+        self.store_status(job_id, JOB_DONE)
+
+        return Outcome(PRINTED, detail, job_id)
+
     def _remember(self, job: Dict[str, Any], status: str) -> None:
         self._call(self.store.save_job, job, self.printer_name, self.batch_id, status)
 
@@ -1147,6 +1196,12 @@ class PrintWorker(_BaseWorker):
             self._reset_pipeline()
 
         self._progress(STEP_CLAIM, DONE, "card %s" % self._card_number(job))
+
+        # The server handed this back, but we may already have printed it.
+        already = self._already_printed(job_id)
+
+        if already is not None:
+            return already
 
         # Cached before anything is printed. From here on the card is committed
         # to: if the network dies we still know what we hold and what to send.

--- a/print-agent/tests/test_reprint_after_restart.py
+++ b/print-agent/tests/test_reprint_after_restart.py
@@ -1,0 +1,102 @@
+"""Closing the agent mid-batch must not reprint the card that already came out.
+
+The server hands a job back once its lease lapses, because from where it sits a
+silent agent is indistinguishable from a dead one. It cannot know whether a card
+reached the output bin. This station can: it wrote down how far the job got.
+"""
+
+import unittest
+
+import agent.worker as worker
+
+from test_worker import WorkerTestCase, job
+
+
+class AlreadyPrintedTest(WorkerTestCase):
+    def setUp(self):
+        super().setUp()
+        self.api.queue.append(job(11, "24-0031"))
+
+    def printed_but_never_reported(self):
+        """The window that produces duplicates.
+
+        The card comes out, then the confirmation cannot be delivered -- the
+        agent was closed, or the network went. The server still has the job
+        outstanding, so once the lease lapses it hands it back. The local row
+        survives as `reported`, which is the evidence this station has and the
+        server does not.
+        """
+        self.api.printed_error = worker.NetworkError("server unreachable")
+        self.build().print_next()
+
+        self.api.printed_error = None
+        self.api.printing = []
+        self.sent = []
+
+    def test_the_first_run_prints_normally(self):
+        outcome = self.build().print_next()
+
+        self.assertEqual(worker.PRINTED, outcome.kind)
+        self.assertEqual(1, len(self.sent))
+
+    def test_a_returned_job_is_not_printed_a_second_time(self):
+        self.printed_but_never_reported()
+        self.api.queue.append(job(11, "24-0031"))   # the server hands it back
+
+        self.build().print_next()
+
+        self.assertEqual([], self.sent)
+
+    def test_it_tells_the_server_the_card_exists(self):
+        # The confirmation the server never received, sent again -- otherwise
+        # the job sits pending and comes round once more.
+        self.printed_but_never_reported()
+        self.api.queue.append(job(11, "24-0031"))
+
+        self.build().print_next()
+
+        self.assertEqual(1, len(self.api.printed))
+        self.assertEqual("recovered", self.api.printed[0]["completion_source"])
+
+    def test_it_reports_the_card_as_printed_rather_than_failed(self):
+        self.printed_but_never_reported()
+        self.api.queue.append(job(11, "24-0031"))
+
+        outcome = self.build().print_next()
+
+        self.assertEqual(worker.PRINTED, outcome.kind)
+        self.assertEqual([], self.api.failed)
+
+    def test_a_card_this_station_never_printed_is_printed(self):
+        # The guard must not swallow honest work: a job with no local history
+        # is a job whose card does not exist.
+        self.api.queue.append(job(12, "24-0032"))
+        w = self.build()
+
+        w.print_next()
+        w.print_next()
+
+        self.assertEqual(2, len(self.sent))
+
+    def test_an_attempt_that_never_confirmed_is_not_treated_as_printed(self):
+        # `printing` is written before the artwork is spooled, so it proves an
+        # attempt, not a card. Reading it as evidence would skip real work.
+        self.store.save_job(job(11, "24-0031"), "ZXP9-Left", 77, worker.JOB_PRINTING)
+
+        self.build().print_next()
+
+        self.assertEqual(1, len(self.sent))
+
+    def test_an_unreadable_store_never_blocks_a_print(self):
+        class Broken:
+            def __getattr__(self, name):
+                raise RuntimeError("disk gone")
+
+        w = self.build()
+        w.store = Broken()
+
+        self.assertIsNone(w._already_printed(11))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/resources/js/Components/Manage/DataTable.vue
+++ b/resources/js/Components/Manage/DataTable.vue
@@ -167,6 +167,72 @@ const someSelected = computed(() => selected.value.length > 0 && !allSelected.va
 
 const toggleAll = () => {
   selected.value = allSelected.value ? [] : props.table.rows.map((row) => row.id);
+  allMatching.value = false;
+};
+
+/**
+ * "Everything the current filter matches", as opposed to the rows that are ticked.
+ *
+ * The browser only ever holds one page of ids, so this is a flag rather than a longer
+ * list: the action posts `all: true` plus the list's own query string, and the server
+ * resolves the set through the same Table that drew the page. Offered only by actions
+ * that declare they understand it - an endpoint reading `ids` and ignoring `all` would
+ * answer "select all 1,204" by acting on the 25 rows on screen.
+ */
+const allMatching = ref(false);
+
+const selectAllActions = computed(() => props.table.bulkActions.filter((action) => action.selectAll));
+
+const matchingTotal = computed(() => props.table.meta?.total ?? 0);
+
+/*
+ * The offer only stands over a fully ticked page with more behind it, and drops the moment
+ * the selection or what the filter matches changes: the flag means "the set I am looking
+ * at", and that set has just become a different one.
+ */
+const canSelectAllMatching = computed(
+  () => selectAllActions.value.length > 0
+    && allSelected.value
+    && matchingTotal.value > props.table.rows.length,
+);
+
+watch(
+  () => [props.table.meta?.total, props.table.search, JSON.stringify(props.table.filters ?? [])],
+  () => {
+    allMatching.value = false;
+  },
+);
+
+watch(selected, (next) => {
+  if (!next.length) {
+    allMatching.value = false;
+  }
+});
+
+/*
+ * While the whole filter is selected, only the actions that can act on it are offered.
+ * Hiding the others is the honest option: leaving them enabled would run them over the
+ * page while the bar says a thousand rows are selected.
+ */
+const offeredActions = computed(() =>
+  allMatching.value ? selectAllActions.value : props.table.bulkActions,
+);
+
+/**
+ * What a bulk action posts: the ticked ids, or the flag plus the list's own query.
+ *
+ * The query string is forwarded verbatim rather than rebuilt as nested data. It is the
+ * exact string that produced the page, so the narrowing cannot drift from what the
+ * operator is looking at, and the server parses it back with the same rules that read it
+ * off a GET. Sort and page ride along and are ignored: a set has no order and no page.
+ */
+const actionData = (action) => (allMatching.value && action.selectAll
+  ? { all: true, query: window.location.search.replace(/^\?/, '') }
+  : { ids: selected.value });
+
+const clearSelection = () => {
+  selected.value = [];
+  allMatching.value = false;
 };
 
 /*
@@ -259,18 +325,40 @@ const open = (row, event) => {
       v-if="selected.length && table.bulkActions.length"
       class="flex h-10 items-center gap-2 border-b border-hairline bg-mg-surface-2 px-3"
     >
-      <span class="text-[12px] text-fg-2">{{ selected.length }} selected</span>
+      <span class="text-[12px] text-fg-2">
+        {{ allMatching ? `all ${matchingTotal} matching selected` : `${selected.length} selected` }}
+      </span>
       <ActionButton
-        v-for="action in table.bulkActions"
+        v-for="action in offeredActions"
         :key="action.name"
         :action="action"
-        :data="{ ids: selected }"
-        @completed="selected = []"
+        :data="actionData(action)"
+        @completed="clearSelection"
       />
+
+      <!-- Past the page. Shown only over a fully ticked page with more behind it, so it
+           never appears while the operator is picking individual rows. -->
+      <button
+        v-if="canSelectAllMatching && !allMatching"
+        type="button"
+        class="text-[12px] font-medium text-state-live underline-offset-2 hover:underline"
+        @click="allMatching = true"
+      >
+        Select all {{ matchingTotal }} matching the filter
+      </button>
+      <button
+        v-else-if="allMatching"
+        type="button"
+        class="text-[12px] text-fg-3 transition-colors hover:text-fg-1"
+        @click="allMatching = false"
+      >
+        Just this page
+      </button>
+
       <button
         type="button"
         class="ml-auto text-[12px] text-fg-3 transition-colors hover:text-fg-1"
-        @click="selected = []"
+        @click="clearSelection"
       >
         Clear
       </button>

--- a/resources/js/Components/POS/InactivityTimer.vue
+++ b/resources/js/Components/POS/InactivityTimer.vue
@@ -64,8 +64,16 @@ const isTimerActive = computed(() => {
         return false;
     }
 
-    // Timer is active on all POS routes except auth routes
-    const isActive = currentRoute.value && currentRoute.value.startsWith('pos.') && !currentRoute.value.startsWith('pos.auth.');
+    // Timer is active on all POS routes except auth routes, and except the
+    // verification screen. Checking a crate off is minutes of handling cards
+    // with no keyboard or mouse in between, and locking there throws away the
+    // list of what was already checked - the one thing the clerk is reading
+    // off the screen. That screen holds no attendee data and no till, so the
+    // lock buys nothing there; it polls the server itself to hold the session.
+    const isActive = currentRoute.value
+        && currentRoute.value.startsWith('pos.')
+        && !currentRoute.value.startsWith('pos.auth.')
+        && !currentRoute.value.startsWith('pos.verification.');
     console.log('[InactivityTimer] Route check:', {
         currentRoute: currentRoute.value,
         isActive,

--- a/resources/js/Components/POS/ShortcutsDialog.vue
+++ b/resources/js/Components/POS/ShortcutsDialog.vue
@@ -14,6 +14,7 @@
       <div><b>Print Queue:</b> <kbd>F4</kbd></div>
       <div><b>Statistics:</b> <kbd>F6</kbd></div>
       <div><b>My Print Jobs:</b> <kbd>F7</kbd></div>
+      <div><b>Badge Verification:</b> <kbd>F8</kbd></div>
       <div><b>This dialog:</b> <kbd>F1</kbd></div>
 
       <h4 class="pos-label mb-2 mt-4">Keyboard</h4>

--- a/resources/js/Pages/POS/Dashboard.vue
+++ b/resources/js/Pages/POS/Dashboard.vue
@@ -219,6 +219,13 @@ const actions = computed(() => [
         count: props.printNotifications.length || null,
     },
     {
+        label: 'Badge Verification',
+        subtitle: 'Check a printed box off',
+        route: route('pos.verification.index'),
+        icon: 'pi pi-check-square',
+        key: 'F8',
+    },
+    {
         label: 'Statistics',
         subtitle: 'Reports & totals',
         route: route('pos.statistics'),

--- a/resources/js/Pages/POS/Verification/Index.vue
+++ b/resources/js/Pages/POS/Verification/Index.vue
@@ -127,26 +127,14 @@ const rangeLabel = computed(() => {
     return "every badge of the event";
 });
 
-const statTiles = computed(() => [
-    {
-        label: "Checked off",
-        value: props.stats?.verified ?? 0,
-        sub: `of ${props.stats?.printed ?? 0} printed`,
-        primary: true,
-        progress: props.stats?.printed
-            ? Math.round((props.stats.verified / props.stats.printed) * 100)
-            : 0,
-    },
-    {
-        label: "Still missing",
-        value: props.stats?.missing ?? 0,
-        sub: "printed, never seen at the desk",
-    },
-    {
-        label: "This desk counts",
-        value: props.stats?.printed ?? 0,
-        sub: rangeLabel.value,
-    },
+// Counters read as one line of text rather than as the dashboard's stat tiles.
+// The two screens are one keystroke apart and both are a number field over a
+// keypad, so this one deliberately does not look like the other: typing an
+// attendee number into the wrong one silently checks a card off.
+const counters = computed(() => [
+    { label: "checked off", value: props.stats?.verified ?? 0 },
+    { label: "still missing", value: props.stats?.missing ?? 0, bad: true },
+    { label: `printed · ${rangeLabel.value}`, value: props.stats?.printed ?? 0 },
 ]);
 
 const resultClass = computed(() => ({
@@ -174,30 +162,71 @@ function verifiedTime(row) {
         <title>POS - Badge Verification</title>
     </Head>
 
+    <!-- Nothing on this screen is shaped like the dashboard: the banner runs the
+         full width, the list is the big half, and the entry column sits on the
+         right with a keypad half the size. The two screens are one keystroke
+         apart and a number typed into the wrong one checks a card off silently. -->
     <div class="w-full flex-1 flex flex-col gap-2">
-        <div class="pos-block pos-block--cols">
-            <div
-                v-for="tile in statTiles"
-                :key="tile.label"
-                class="pos-stat"
-                :class="tile.primary ? 'pos-stat--primary' : ''"
-            >
-                <span class="pos-stat__k">{{ tile.label }}</span>
-                <span class="pos-stat__v">{{ tile.value }}</span>
-                <span class="pos-stat__sub">{{ tile.sub }}</span>
-                <span v-if="tile.progress !== undefined" class="pos-meter" :aria-label="`${tile.progress}% checked off`">
-                    <span class="pos-meter__fill" :style="{ width: `${Math.min(100, tile.progress)}%` }"></span>
-                </span>
+        <div class="rounded-pos border-2 border-pos-warn bg-pos-warn/10 px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+            <div>
+                <h1 class="text-base font-bold tracking-wide uppercase text-pos-warn">
+                    Verification mode
+                </h1>
+                <p class="text-xs text-pos-muted">
+                    Reading numbers off the cards in the box. Nothing is handed out and no attendee is looked up here.
+                </p>
+            </div>
+
+            <div class="flex items-center gap-4">
+                <div v-for="counter in counters" :key="counter.label" class="text-right">
+                    <span
+                        class="block pos-num text-2xl font-bold leading-none"
+                        :class="counter.bad && counter.value > 0 ? 'text-pos-bad' : ''"
+                    >{{ counter.value }}</span>
+                    <span class="block text-[0.68rem] uppercase tracking-wide text-pos-muted">{{ counter.label }}</span>
+                </div>
             </div>
         </div>
 
-        <div class="flex-1 grid grid-cols-1 lg:grid-cols-3 gap-2">
-            <section class="lg:col-span-2 pos-card flex flex-col">
+        <div class="flex-1 grid grid-cols-1 lg:grid-cols-5 gap-2">
+            <section class="lg:col-span-3 pos-card flex flex-col">
                 <div class="pos-card__head">
-                    <h1>Check the box</h1>
-                    <div class="flex items-center gap-3 text-xs text-pos-muted">
-                        <span><span class="pos-kcap mr-1">0-9</span>badge</span>
-                        <span><span class="pos-kcap mr-1">-</span>copy</span>
+                    <h2>Checked off in this box</h2>
+                    <span class="text-xs text-pos-muted">
+                        {{ recent.length ? `last ${recent.length}` : 'nothing yet' }}
+                    </span>
+                </div>
+
+                <p v-if="!recent.length" class="text-sm text-pos-muted px-1 py-4">
+                    Type the number printed on the first card to start. Every card you check off
+                    lands here, newest first, with an Undo beside it.
+                </p>
+
+                <div v-else class="pos-block pos-block--rows w-full flex-1 max-h-[34rem] overflow-y-auto">
+                    <div v-for="row in recent" :key="row.id" class="pos-row">
+                        <div class="pos-row__body">
+                            <span class="pos-row__title pos-num text-lg">{{ row.custom_id }}</span>
+                            <span class="pos-row__sub">
+                                {{ verifiedTime(row) }}
+                                · {{ row.fursuit_name || 'unknown fursuit' }}
+                                <template v-if="row.owner_name"> · {{ row.owner_name }}</template>
+                            </span>
+                        </div>
+                        <button
+                            type="button"
+                            class="pos-btn pos-btn--quiet"
+                            @click="revert(row)"
+                        >
+                            Undo
+                        </button>
+                    </div>
+                </div>
+            </section>
+
+            <section class="lg:col-span-2 pos-card flex flex-col self-start w-full">
+                <div class="pos-card__head">
+                    <h2>Card number</h2>
+                    <div class="flex items-center gap-2 text-xs text-pos-muted">
                         <span><span class="pos-kcap mr-1">Enter</span>check off</span>
                         <span><span class="pos-kcap mr-1">/</span>clear</span>
                     </div>
@@ -211,71 +240,39 @@ function verifiedTime(row) {
                 >
                     {{ result.message }}
                 </p>
-                <p v-else class="mb-2 px-3 py-2 text-sm text-pos-muted">
-                    Type the number on the card and press Enter. A bare number is copy 1,
-                    so 1234 checks off 1234-1; a second copy needs 1234-2 in full.
+                <p v-else class="mb-2 text-xs text-pos-muted">
+                    A bare number is copy 1: 1234 checks off 1234-1. A second copy needs
+                    1234-2 typed in full.
                 </p>
 
-                <form class="flex gap-2" @submit.prevent="submit">
+                <form class="flex flex-col gap-2" @submit.prevent="submit">
                     <input
                         ref="badgeIdInput"
                         v-model="form.badge_id"
-                        class="pos-field"
+                        class="pos-field text-center"
                         type="text"
                         inputmode="numeric"
                         autocomplete="off"
-                        placeholder="Badge number"
+                        placeholder="0000-0"
                         maxlength="12"
                     />
                     <button
                         type="submit"
-                        class="pos-btn pos-btn--primary pos-btn--commit px-8"
+                        class="pos-btn pos-btn--primary pos-btn--commit"
                         :disabled="!form.badge_id || form.processing"
                     >
                         Check off <span class="pos-kcap">Enter</span>
                     </button>
                 </form>
 
-                <div class="flex-1 flex items-center justify-center mt-2">
-                    <div class="pos-keypad w-full max-w-md h-full max-h-[24rem]">
-                        <button v-for="n in ['7','8','9','4','5','6','1','2','3']" :key="n"
-                                type="button" class="pos-key" @click="keyPress(n)">{{ n }}</button>
-                        <button type="button" class="pos-key" @click="keyPress('-')">-</button>
-                        <button type="button" class="pos-key" @click="keyPress('0')">0</button>
-                        <button type="button" class="pos-key pos-key--wide" @click="keyPress('delete')">Delete</button>
-                        <button type="button" class="pos-key pos-key--go col-span-3" @click="keyPress('enter')">Check off</button>
-                    </div>
-                </div>
-            </section>
-
-            <section class="pos-card flex flex-col self-start w-full">
-                <div class="pos-card__head">
-                    <h2>Just checked off</h2>
-                    <span class="text-xs text-pos-muted">{{ recent.length }} shown</span>
-                </div>
-
-                <p v-if="!recent.length" class="text-sm text-pos-muted px-1 py-4">
-                    Nothing checked off yet.
-                </p>
-
-                <div v-else class="pos-block pos-block--rows w-full max-h-[32rem] overflow-y-auto">
-                    <div v-for="row in recent" :key="row.id" class="pos-row">
-                        <div class="pos-row__body">
-                            <span class="pos-row__title">{{ row.custom_id }}</span>
-                            <span class="pos-row__sub">
-                                {{ row.fursuit_name || 'unknown fursuit' }}
-                                <template v-if="row.owner_name"> · {{ row.owner_name }}</template>
-                                · {{ verifiedTime(row) }}
-                            </span>
-                        </div>
-                        <button
-                            type="button"
-                            class="pos-btn pos-btn--quiet"
-                            @click="revert(row)"
-                        >
-                            Undo
-                        </button>
-                    </div>
+                <!-- Half the dashboard keypad's size: the desk numpad does the typing,
+                     and this is the fallback for a touchscreen. -->
+                <div class="pos-keypad w-full max-w-[15rem] mx-auto mt-3">
+                    <button v-for="n in ['7','8','9','4','5','6','1','2','3']" :key="n"
+                            type="button" class="pos-key" @click="keyPress(n)">{{ n }}</button>
+                    <button type="button" class="pos-key" @click="keyPress('-')">-</button>
+                    <button type="button" class="pos-key" @click="keyPress('0')">0</button>
+                    <button type="button" class="pos-key pos-key--wide" @click="keyPress('delete')">Delete</button>
                 </div>
             </section>
         </div>

--- a/resources/js/Pages/POS/Verification/Index.vue
+++ b/resources/js/Pages/POS/Verification/Index.vue
@@ -1,0 +1,283 @@
+<script setup>
+import { Head, router, useForm } from "@inertiajs/vue3";
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
+import POSLayout from "@/Layouts/POSLayout.vue";
+import { usePosKeyboard } from "@/composables/usePosKeyboard";
+
+defineOptions({
+    layout: POSLayout,
+});
+
+const props = defineProps({
+    stats: Object,
+    badgeRange: Object,
+    recent: {
+        type: Array,
+        default: () => [],
+    },
+    result: {
+        type: Object,
+        default: null,
+    },
+});
+
+const badgeIdInput = ref(null);
+
+const form = useForm({
+    badge_id: "",
+});
+
+function focusInput() {
+    nextTick(() => badgeIdInput.value?.focus());
+}
+
+function submit() {
+    if (! form.badge_id || form.processing) {
+        return;
+    }
+
+    form.post(route("pos.verification.store"), {
+        preserveScroll: true,
+        onFinish: () => {
+            // Cleared either way: a rejected number stays visible in the banner,
+            // and leaving it in the field means the next card gets typed onto
+            // the end of it.
+            form.badge_id = "";
+            focusInput();
+        },
+    });
+}
+
+// The numpad has a minus key, so a second copy can be typed as 1234-2 without
+// leaving the keypad. A bare number is the first copy; the server decides that.
+function keyPress(key) {
+    if (key === "delete") {
+        form.badge_id = form.badge_id.slice(0, -1);
+    } else if (key === "enter") {
+        submit();
+    } else {
+        form.badge_id += key;
+    }
+    focusInput();
+}
+
+function revert(badge) {
+    router.post(route("pos.verification.revert", { badge: badge.id }), {}, {
+        preserveScroll: true,
+        onFinish: focusInput,
+    });
+}
+
+// Scanners and the keypad emit stray characters; digits and one dash are the
+// whole alphabet of a badge number.
+watch(() => form.badge_id, (value) => {
+    const cleaned = (value || "").replace(/[^\d-]/g, "").slice(0, 12);
+    if (cleaned !== value) {
+        form.badge_id = cleaned;
+    }
+});
+
+// Numpad "/" is "start over" here rather than "go to the dashboard": the field
+// on this screen is the one the clerk is already typing into.
+usePosKeyboard({
+    onNumpadDivide: () => {
+        form.badge_id = "";
+        focusInput();
+    },
+});
+
+/* --- Keeping the screen alive -------------------------------------------- */
+
+// Working a crate means long silences: read a card, put it on the pile, pick up
+// the next one. The auto-lock is suspended for this route (InactivityTimer), and
+// this poll is the other half of it - it keeps the session from expiring under
+// the same silence, and refreshes the list when a second desk works the same
+// crate. Nothing typed is held in the browser, so a reload loses nothing.
+let keepAliveTimer = null;
+
+onMounted(() => {
+    focusInput();
+    keepAliveTimer = setInterval(() => {
+        router.reload({
+            only: ["stats", "recent"],
+            preserveState: true,
+            preserveScroll: true,
+        });
+    }, 60000);
+});
+
+onUnmounted(() => clearInterval(keepAliveTimer));
+
+/* --- Presentation --------------------------------------------------------- */
+
+const rangeLabel = computed(() => {
+    const min = props.badgeRange?.min;
+    const max = props.badgeRange?.max;
+
+    if (min !== null && min !== undefined && max !== null && max !== undefined) {
+        return `attendee ${min} to ${max}`;
+    }
+    if (min !== null && min !== undefined) {
+        return `attendee ${min} and up`;
+    }
+    if (max !== null && max !== undefined) {
+        return `attendee up to ${max}`;
+    }
+
+    return "every badge of the event";
+});
+
+const statTiles = computed(() => [
+    {
+        label: "Checked off",
+        value: props.stats?.verified ?? 0,
+        sub: `of ${props.stats?.printed ?? 0} printed`,
+        primary: true,
+        progress: props.stats?.printed
+            ? Math.round((props.stats.verified / props.stats.printed) * 100)
+            : 0,
+    },
+    {
+        label: "Still missing",
+        value: props.stats?.missing ?? 0,
+        sub: "printed, never seen at the desk",
+    },
+    {
+        label: "This desk counts",
+        value: props.stats?.printed ?? 0,
+        sub: rangeLabel.value,
+    },
+]);
+
+const resultClass = computed(() => ({
+    ok: "border-pos-good text-pos-good",
+    duplicate: "border-pos-warn text-pos-warn",
+    reverted: "border-pos-line text-pos-muted",
+    error: "border-pos-bad text-pos-bad",
+}[props.result?.status] ?? "border-pos-line text-pos-muted"));
+
+function verifiedTime(row) {
+    if (! row.verified_at) {
+        return "";
+    }
+
+    return new Date(row.verified_at).toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+    });
+}
+</script>
+
+<template>
+    <Head>
+        <title>POS - Badge Verification</title>
+    </Head>
+
+    <div class="w-full flex-1 flex flex-col gap-2">
+        <div class="pos-block pos-block--cols">
+            <div
+                v-for="tile in statTiles"
+                :key="tile.label"
+                class="pos-stat"
+                :class="tile.primary ? 'pos-stat--primary' : ''"
+            >
+                <span class="pos-stat__k">{{ tile.label }}</span>
+                <span class="pos-stat__v">{{ tile.value }}</span>
+                <span class="pos-stat__sub">{{ tile.sub }}</span>
+                <span v-if="tile.progress !== undefined" class="pos-meter" :aria-label="`${tile.progress}% checked off`">
+                    <span class="pos-meter__fill" :style="{ width: `${Math.min(100, tile.progress)}%` }"></span>
+                </span>
+            </div>
+        </div>
+
+        <div class="flex-1 grid grid-cols-1 lg:grid-cols-3 gap-2">
+            <section class="lg:col-span-2 pos-card flex flex-col">
+                <div class="pos-card__head">
+                    <h1>Check the box</h1>
+                    <div class="flex items-center gap-3 text-xs text-pos-muted">
+                        <span><span class="pos-kcap mr-1">0-9</span>badge</span>
+                        <span><span class="pos-kcap mr-1">-</span>copy</span>
+                        <span><span class="pos-kcap mr-1">Enter</span>check off</span>
+                        <span><span class="pos-kcap mr-1">/</span>clear</span>
+                    </div>
+                </div>
+
+                <p
+                    v-if="result"
+                    class="mb-2 px-3 py-2 rounded-pos border text-sm font-semibold"
+                    :class="resultClass"
+                    aria-live="polite"
+                >
+                    {{ result.message }}
+                </p>
+                <p v-else class="mb-2 px-3 py-2 text-sm text-pos-muted">
+                    Type the number on the card and press Enter. A bare number is copy 1,
+                    so 1234 checks off 1234-1; a second copy needs 1234-2 in full.
+                </p>
+
+                <form class="flex gap-2" @submit.prevent="submit">
+                    <input
+                        ref="badgeIdInput"
+                        v-model="form.badge_id"
+                        class="pos-field"
+                        type="text"
+                        inputmode="numeric"
+                        autocomplete="off"
+                        placeholder="Badge number"
+                        maxlength="12"
+                    />
+                    <button
+                        type="submit"
+                        class="pos-btn pos-btn--primary pos-btn--commit px-8"
+                        :disabled="!form.badge_id || form.processing"
+                    >
+                        Check off <span class="pos-kcap">Enter</span>
+                    </button>
+                </form>
+
+                <div class="flex-1 flex items-center justify-center mt-2">
+                    <div class="pos-keypad w-full max-w-md h-full max-h-[24rem]">
+                        <button v-for="n in ['7','8','9','4','5','6','1','2','3']" :key="n"
+                                type="button" class="pos-key" @click="keyPress(n)">{{ n }}</button>
+                        <button type="button" class="pos-key" @click="keyPress('-')">-</button>
+                        <button type="button" class="pos-key" @click="keyPress('0')">0</button>
+                        <button type="button" class="pos-key pos-key--wide" @click="keyPress('delete')">Delete</button>
+                        <button type="button" class="pos-key pos-key--go col-span-3" @click="keyPress('enter')">Check off</button>
+                    </div>
+                </div>
+            </section>
+
+            <section class="pos-card flex flex-col self-start w-full">
+                <div class="pos-card__head">
+                    <h2>Just checked off</h2>
+                    <span class="text-xs text-pos-muted">{{ recent.length }} shown</span>
+                </div>
+
+                <p v-if="!recent.length" class="text-sm text-pos-muted px-1 py-4">
+                    Nothing checked off yet.
+                </p>
+
+                <div v-else class="pos-block pos-block--rows w-full max-h-[32rem] overflow-y-auto">
+                    <div v-for="row in recent" :key="row.id" class="pos-row">
+                        <div class="pos-row__body">
+                            <span class="pos-row__title">{{ row.custom_id }}</span>
+                            <span class="pos-row__sub">
+                                {{ row.fursuit_name || 'unknown fursuit' }}
+                                <template v-if="row.owner_name"> · {{ row.owner_name }}</template>
+                                · {{ verifiedTime(row) }}
+                            </span>
+                        </div>
+                        <button
+                            type="button"
+                            class="pos-btn pos-btn--quiet"
+                            @click="revert(row)"
+                        >
+                            Undo
+                        </button>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+</template>

--- a/resources/js/composables/usePosKeyboard.js
+++ b/resources/js/composables/usePosKeyboard.js
@@ -48,6 +48,7 @@ export function usePosKeyboard(options = {}) {
         F6: '/pos/statistics',
         // F5 is the browser reload and stays out of this map; F7 is free.
         F7: '/pos/my-prints',
+        F8: '/pos/verification',
     };
 
     function handleKeydown(event) {

--- a/routes/pos.php
+++ b/routes/pos.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\POS\AttendeeController;
 use App\Http\Controllers\POS\BadgeController;
 use App\Http\Controllers\POS\BadgeEditController;
 use App\Http\Controllers\POS\BadgeManagementController;
+use App\Http\Controllers\POS\BadgeVerificationController;
 use App\Http\Controllers\POS\CheckoutController;
 use App\Http\Controllers\POS\DashboardController;
 use App\Http\Controllers\POS\MachineController;
@@ -56,6 +57,12 @@ Route::prefix('/my-prints')->name('my-prints.')->group(function () {
     Route::get('/', [MyPrintsController::class, 'index'])->name('index');
     Route::post('/dismiss-all', [MyPrintsController::class, 'dismissAll'])->name('dismiss-all');
     Route::post('/{printBatch}/dismiss', [MyPrintsController::class, 'dismiss'])->name('dismiss');
+});
+// Checking the printed crate off card by card. See BadgeVerificationController.
+Route::prefix('/verification')->name('verification.')->group(function () {
+    Route::get('/', [BadgeVerificationController::class, 'index'])->name('index');
+    Route::post('/', [BadgeVerificationController::class, 'store'])->name('store');
+    Route::post('/{badge}/revert', [BadgeVerificationController::class, 'revert'])->name('revert');
 });
 // Statistics
 Route::get('/statistics', [StatisticsController::class, 'index'])->name('statistics');

--- a/tests/Feature/Manage/BadgePrintTest.php
+++ b/tests/Feature/Manage/BadgePrintTest.php
@@ -306,6 +306,104 @@ test('the print order is the batch\'s own, not a second one layered on top', fun
         ->toBe([$spare->id, $main->id, $later->id]);
 });
 
+/*
+ * "Select all matching": the run is the whole of what the filter matches, resolved on the
+ * server. The browser holds one page of ids and the operator is asking for the thousand
+ * behind them, so anything the client could send is the wrong answer.
+ */
+
+test('select all matching queues every badge the filter matches, not the ids posted', function () {
+    $first = ($this->badge)('0100-1');
+    $second = ($this->badge)('0101-1');
+    $third = ($this->badge)('0102-1');
+
+    actingAs($this->admin)->post(route('admin.badges.bulk.print'), [
+        'all' => true,
+        // Deliberately naming one badge: `all` means the filter, and `ids` is ignored.
+        'ids' => [$first->id],
+        'query' => '',
+        'printer_id' => $this->printer->id,
+    ])->assertRedirect()->assertSessionHasNoErrors();
+
+    expect(PrintBatch::sole()->printJobs()->pluck('printable_id')->sort()->values()->all())
+        ->toBe(collect([$first->id, $second->id, $third->id])->sort()->values()->all());
+});
+
+test('select all matching narrows by the filters the list was drawn with', function () {
+    $pending = ($this->badge)('0100-1');
+    ($this->badge)('0101-1', ['status_fulfillment' => 'picked_up']);
+
+    actingAs($this->admin)->post(route('admin.badges.bulk.print'), [
+        'all' => true,
+        'query' => http_build_query(['filter' => ['status_fulfillment' => ['pending']]]),
+        'printer_id' => $this->printer->id,
+    ])->assertRedirect()->assertSessionHasNoErrors();
+
+    expect(PrintBatch::sole()->printJobs()->pluck('printable_id')->all())->toBe([$pending->id]);
+});
+
+test('select all matching stays inside the selected event', function () {
+    $mine = ($this->badge)('0100-1');
+
+    $otherEvent = Event::factory()->create(['name' => 'Eurofurence 28', 'starts_at' => now()->subYear()]);
+    $stranger = User::factory()->create();
+    EventUser::factory()->create([
+        'user_id' => $stranger->id,
+        'event_id' => $otherEvent->id,
+        'attendee_id' => '0900',
+    ]);
+    Badge::factory()->withPrintFile()->create([
+        'custom_id' => '0900-1',
+        'status_fulfillment' => 'pending',
+        'status_payment' => 'paid',
+        'fursuit_id' => Fursuit::factory()->create([
+            'event_id' => $otherEvent->id,
+            'user_id' => $stranger->id,
+            'species_id' => Species::firstOrCreate(['name' => 'Blue Fox'], ['type' => 'canine', 'checked' => true])->id,
+        ])->id,
+    ]);
+
+    // The event scope is session state, not something the forwarded query can widen.
+    actingAs($this->admin)
+        ->withSession([EventScope::SESSION_ID => $this->event->id, EventScope::SESSION_CHOSEN => true])
+        ->post(route('admin.badges.bulk.print'), [
+            'all' => true,
+            'query' => '',
+            'printer_id' => $this->printer->id,
+        ])->assertRedirect()->assertSessionHasNoErrors();
+
+    expect(PrintBatch::sole()->printJobs()->pluck('printable_id')->all())->toBe([$mine->id]);
+});
+
+test('select all matching needs no ids at all', function () {
+    ($this->badge)('0100-1');
+
+    actingAs($this->admin)->post(route('admin.badges.bulk.print'), [
+        'all' => true,
+        'printer_id' => $this->printer->id,
+    ])->assertRedirect()->assertSessionHasNoErrors();
+
+    expect(PrintBatch::count())->toBe(1);
+});
+
+test('a bulk print with neither ids nor all is a validation error', function () {
+    actingAs($this->admin)->post(route('admin.badges.bulk.print'), [
+        'printer_id' => $this->printer->id,
+    ])->assertSessionHasErrors('ids');
+
+    expect(PrintBatch::count())->toBe(0);
+});
+
+test('only the print action offers to go past the page', function () {
+    ($this->badge)();
+
+    $props = ($this->scoped)()->get(route('admin.badges.index'))->viewData('page')['props'];
+
+    // The fulfillment write bypasses the state machine, so it stays page-only.
+    expect(collect($props['bulkActions'])->firstWhere('name', 'printBadgeBulk')['selectAll'])->toBeTrue()
+        ->and(collect($props['bulkActions'])->firstWhere('name', 'setFulfillmentStatus')['selectAll'])->toBeFalse();
+});
+
 test('the bulk action requires a printer and queues nothing without one', function () {
     $badge = ($this->badge)();
 

--- a/tests/Feature/Manage/BadgesTest.php
+++ b/tests/Feature/Manage/BadgesTest.php
@@ -16,6 +16,8 @@
  *  - a badge whose fursuit or user is soft-deleted took the whole table down.
  *
  * The rest is parity, transcribed from the audit: fourteen columns in order, four filters,
+ * plus what was added afterwards - the Verified column and the print_verified filter that
+ * the POS check-off screen is read through.
  * five form sections, and the old panel's own delete copy.
  */
 
@@ -104,7 +106,7 @@ beforeEach(function () {
     ]);
 });
 
-test('the list renders the fourteen columns in order, with their labels and types', function () {
+test('the list renders the fifteen columns in order, with their labels and types', function () {
     ($this->badge)();
 
     ($this->scoped)(null)->get(route('admin.badges.index'))
@@ -125,9 +127,12 @@ test('the list renders the fourteen columns in order, with their labels and type
             ->where('columns.11', fn ($c) => $c['key'] === 'created_at' && $c['label'] === 'Created' && $c['hiddenByDefault'])
             ->where('columns.12', fn ($c) => $c['key'] === 'printed_at' && $c['label'] === 'Printed At' && $c['fallback'] === 'Not printed' && $c['hiddenByDefault'])
             ->where('columns.13', fn ($c) => $c['key'] === 'picked_up_at' && $c['label'] === 'Picked Up' && $c['fallback'] === 'Not picked up' && $c['hiddenByDefault'])
-            ->count('columns', 14)
-            // The five isToggledHiddenByDefault: true flags, and only those five.
-            ->where('hiddenColumns', ['extra_copy', 'total', 'created_at', 'printed_at', 'picked_up_at'])
+            // Column 15 is not the audit's: it is the desk check-off, added with the POS
+            // verification screen so the printed-but-never-seen cards can be listed.
+            ->where('columns.14', fn ($c) => $c['key'] === 'verified_print_at' && $c['label'] === 'Verified' && $c['fallback'] === 'Not verified' && $c['hiddenByDefault'])
+            ->count('columns', 15)
+            // The five isToggledHiddenByDefault: true flags from the audit, plus Verified.
+            ->where('hiddenColumns', ['extra_copy', 'total', 'created_at', 'printed_at', 'picked_up_at', 'verified_print_at'])
         );
 });
 
@@ -184,7 +189,7 @@ test('the attendee-id sort flips through the partial reload the client actually 
         // The five requested keys have to carry data, not null.
         ->and($descending->json('props.meta.page'))->toBe(1)
         ->and($descending->json('props.search'))->toBe('')
-        ->and($descending->json('props.filters'))->toHaveCount(6);
+        ->and($descending->json('props.filters'))->toHaveCount(7);
 
     expect($partial(['sort' => 'sort_attendee_id', 'dir' => 'asc'])->json('props.rows.0.id'))->toBe($ninth->id);
 });
@@ -319,7 +324,7 @@ test('the list declares its filters with their labels, placeholders and option s
 
     ($this->scoped)(null)->get(route('admin.badges.index'))
         ->assertInertia(fn (Assert $page) => $page
-            ->count('filters', 6)
+            ->count('filters', 7)
             ->where('filters.0.key', 'status_fulfillment')
             ->where('filters.0.label', 'Fulfillment Status')
             ->where('filters.0.placeholder', 'All Statuses')
@@ -358,6 +363,14 @@ test('the list declares its filters with their labels, placeholders and option s
             ->where('filters.5.type', 'datetime')
             ->where('filters.5.label', 'Approved until')
             ->where('filters.5.chipLabel', 'Approved before')
+            // Not the audit's either: the reprint list. Printed, and never checked off
+            // at the desk or seen by the print agent's camera.
+            ->where('filters.6.key', 'print_verified')
+            ->where('filters.6.type', 'ternary')
+            ->where('filters.6.label', 'Print Verified')
+            ->where('filters.6.placeholder', 'Verified or not')
+            ->where('filters.6.trueLabel', 'Verified')
+            ->where('filters.6.falseLabel', 'Not verified')
             // Nothing is filtered on first load; every filter opens blank.
             ->where('filters.0.value', [])
             ->where('filters.1.value', [])
@@ -365,6 +378,7 @@ test('the list declares its filters with their labels, placeholders and option s
             ->where('filters.3.value', ['min' => '', 'max' => ''])
             ->where('filters.4.value', '')
             ->where('filters.5.value', '')
+            ->where('filters.6.value', '')
         );
 });
 

--- a/tests/Feature/POS/BadgeVerificationTest.php
+++ b/tests/Feature/POS/BadgeVerificationTest.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Tests\Feature\POS;
+
+use App\Domain\Printing\Models\PrintJob;
+use App\Enum\PrintJobStatusEnum;
+use App\Enum\PrintJobTypeEnum;
+use App\Enum\PrintVerificationSourceEnum;
+use App\Models\Badge\Badge;
+use App\Models\Event;
+use App\Models\EventUser;
+use App\Models\Fursuit\Fursuit;
+use App\Models\Machine;
+use App\Models\Species;
+use App\Models\Staff;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Checking a crate of printed cards off, card by card.
+ *
+ * The screen exists to answer one question at the end of the crate: which cards
+ * were printed and never turned up. Everything here is a way of getting that
+ * answer wrong - a copy checked off in place of its sibling, a number typed
+ * twice, a card checked off that is not in your hand.
+ */
+class BadgeVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Event $event;
+
+    private Machine $machine;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->event = Event::factory()->create([
+            'starts_at' => now()->subDay(),
+            'ends_at' => now()->addDay(),
+            'order_starts_at' => now()->subDays(10),
+            'order_ends_at' => now()->subDays(5),
+        ]);
+
+        $this->machine = Machine::factory()->create();
+
+        $this->actingAs($this->machine, 'machine')
+            ->actingAs(Staff::factory()->create(['name' => 'Desk staff']), 'machine-user');
+    }
+
+    /**
+     * A printed badge belonging to one attendee, with its custom_id already
+     * allocated - which is what the fulfillment transition does, and what the
+     * number on the physical card is.
+     */
+    private function printedBadge(string $attendeeId, int $copy = 1): Badge
+    {
+        $user = User::factory()->create();
+
+        EventUser::factory()->create([
+            'user_id' => $user->id,
+            'event_id' => $this->event->id,
+            'attendee_id' => $attendeeId,
+        ]);
+
+        return $this->copyFor($user, $attendeeId, $copy);
+    }
+
+    private function copyFor(User $user, string $attendeeId, int $copy): Badge
+    {
+        $fursuit = Fursuit::factory()->create([
+            'user_id' => $user->id,
+            'event_id' => $this->event->id,
+            'species_id' => Species::factory()->create()->id,
+            'status' => 'approved',
+        ]);
+
+        return Badge::factory()->create([
+            'fursuit_id' => $fursuit->id,
+            'custom_id' => $attendeeId.'-'.$copy,
+            'status_fulfillment' => 'ready_for_pickup',
+            'status_payment' => 'paid',
+            'printed_at' => now()->subHour(),
+        ]);
+    }
+
+    private function printJobFor(Badge $badge): PrintJob
+    {
+        return PrintJob::factory()->create([
+            'printable_type' => $badge::class,
+            'printable_id' => $badge->id,
+            'type' => PrintJobTypeEnum::Badge,
+            'status' => PrintJobStatusEnum::Printed,
+            'printed_at' => now()->subHour(),
+        ]);
+    }
+
+    public function test_a_bare_attendee_number_checks_off_the_first_copy(): void
+    {
+        $badge = $this->printedBadge('1234');
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234'])
+            ->assertRedirect();
+
+        $this->assertNotNull($badge->fresh()->verified_print_at);
+    }
+
+    public function test_a_second_copy_has_to_be_typed_in_full(): void
+    {
+        $first = $this->printedBadge('1234');
+        $second = $this->copyFor($first->fursuit->user, '1234', 2);
+
+        // The bare number is copy 1 and nothing else: guessing which copy is in
+        // the operator's hand is the mistake this screen exists to catch.
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234']);
+
+        $this->assertNotNull($first->fresh()->verified_print_at);
+        $this->assertNull($second->fresh()->verified_print_at);
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234-2']);
+
+        $this->assertNotNull($second->fresh()->verified_print_at);
+    }
+
+    public function test_the_stamp_goes_through_the_print_job_so_the_agent_and_the_desk_agree(): void
+    {
+        $badge = $this->printedBadge('1234');
+        $job = $this->printJobFor($badge);
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234']);
+
+        $job->refresh();
+
+        $this->assertNotNull($job->verified_print_at);
+        $this->assertSame(PrintVerificationSourceEnum::Operator, $job->verification_source);
+        $this->assertNotNull($badge->fresh()->verified_print_at);
+    }
+
+    public function test_a_badge_with_no_print_job_is_still_checkable_off(): void
+    {
+        $badge = $this->printedBadge('1234');
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234']);
+
+        $this->assertNotNull($badge->fresh()->verified_print_at);
+    }
+
+    public function test_a_number_typed_twice_says_so_and_keeps_the_first_stamp(): void
+    {
+        $badge = $this->printedBadge('1234');
+
+        $this->travelTo(now()->subMinutes(10));
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234']);
+        $this->travelBack();
+
+        $stamped = $badge->fresh()->verified_print_at;
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234'])
+            ->assertSessionHas('verification', fn (array $result) => $result['status'] === 'duplicate');
+
+        $this->assertTrue($badge->fresh()->verified_print_at->equalTo($stamped));
+    }
+
+    public function test_an_unknown_attendee_and_a_missing_copy_are_told_apart(): void
+    {
+        $this->printedBadge('1234');
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '9999'])
+            ->assertSessionHas('verification', fn (array $result) => $result['status'] === 'error'
+                && str_contains($result['message'], 'No attendee 9999'));
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234-3'])
+            ->assertSessionHas('verification', fn (array $result) => $result['status'] === 'error'
+                && str_contains($result['message'], 'no copy 3'));
+    }
+
+    public function test_a_number_that_is_not_a_badge_number_is_refused(): void
+    {
+        $this->post(route('pos.verification.store'), ['badge_id' => 'abc'])
+            ->assertSessionHas('verification', fn (array $result) => $result['status'] === 'error');
+    }
+
+    public function test_undo_puts_the_card_back_on_the_missing_list(): void
+    {
+        $badge = $this->printedBadge('1234');
+        $job = $this->printJobFor($badge);
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234']);
+        $this->post(route('pos.verification.revert', ['badge' => $badge->id]))
+            ->assertRedirect();
+
+        $this->assertNull($badge->fresh()->verified_print_at);
+        $this->assertNull($job->fresh()->verified_print_at);
+        $this->assertNull($job->fresh()->verification_source);
+    }
+
+    public function test_the_screen_counts_the_crate_and_lists_what_was_checked_off(): void
+    {
+        $checked = $this->printedBadge('1234');
+        $this->printedBadge('1235');
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234']);
+
+        $this->get(route('pos.verification.index'))
+            ->assertSuccessful()
+            ->assertInertia(fn ($page) => $page
+                ->component('POS/Verification/Index')
+                ->where('stats.printed', 2)
+                ->where('stats.verified', 1)
+                ->where('stats.missing', 1)
+                ->where('recent.0.custom_id', $checked->custom_id)
+                ->count('recent', 1)
+                ->etc()
+            );
+    }
+
+    public function test_the_counters_follow_the_crate_this_desk_holds(): void
+    {
+        $this->machine->update(['badge_range_min' => 1000, 'badge_range_max' => 1999]);
+
+        $this->printedBadge('1234');
+        $this->printedBadge('2500');
+
+        $this->get(route('pos.verification.index'))
+            ->assertInertia(fn ($page) => $page
+                ->where('stats.printed', 1)
+                ->where('stats.missing', 1)
+                ->etc()
+            );
+    }
+
+    public function test_the_screen_needs_a_signed_in_staff_member(): void
+    {
+        auth('machine-user')->logout();
+        auth('machine')->logout();
+
+        $this->get(route('pos.verification.index'))->assertRedirect();
+        $this->post(route('pos.verification.store'), ['badge_id' => '1234'])->assertRedirect();
+    }
+}

--- a/tests/Feature/POS/BadgeVerificationTest.php
+++ b/tests/Feature/POS/BadgeVerificationTest.php
@@ -216,6 +216,42 @@ class BadgeVerificationTest extends TestCase
             );
     }
 
+    public function test_a_card_the_print_pipeline_promoted_still_counts(): void
+    {
+        // The print pipeline never goes through ToPrinted: a finished job calls
+        // promoteBadgeToReadyForPickup(), so printed_at stays null on every card
+        // printed by the agent. Counting on that column read zero cards on live
+        // data while the crate was full of them.
+        $badge = $this->printedBadge('1234');
+        $badge->forceFill(['printed_at' => null])->saveQuietly();
+
+        $this->get(route('pos.verification.index'))
+            ->assertInertia(fn ($page) => $page
+                ->where('stats.printed', 1)
+                ->where('stats.missing', 1)
+                ->etc()
+            );
+    }
+
+    public function test_a_checked_off_card_always_shows_in_the_list(): void
+    {
+        // Outside this desk's crate, so the counters ignore it - but it was
+        // typed into this field, so the list has to show it. Answering
+        // "checked off" over an empty list reads as a failed check-off.
+        $this->machine->update(['badge_range_min' => 1000, 'badge_range_max' => 1999]);
+
+        $this->printedBadge('2500');
+
+        $this->post(route('pos.verification.store'), ['badge_id' => '2500']);
+
+        $this->get(route('pos.verification.index'))
+            ->assertInertia(fn ($page) => $page
+                ->where('recent.0.custom_id', '2500-1')
+                ->count('recent', 1)
+                ->etc()
+            );
+    }
+
     public function test_the_counters_follow_the_crate_this_desk_holds(): void
     {
         $this->machine->update(['badge_range_min' => 1000, 'badge_range_max' => 1999]);

--- a/tests/Feature/Printing/LeaseExpiryTest.php
+++ b/tests/Feature/Printing/LeaseExpiryTest.php
@@ -3,6 +3,7 @@
 use App\Domain\Printing\Models\PrintBatch;
 use App\Domain\Printing\Models\Printer;
 use App\Enum\PrintBatchStatusEnum;
+use App\Enum\PrintCompletionSourceEnum;
 use App\Enum\PrintJobStatusEnum;
 use App\Models\Badge\Badge;
 use App\Models\Machine;
@@ -97,4 +98,68 @@ it('still fails a claimed card that has been round too many times', function () 
     $this->artisan('printing:reap-leases')->assertExitCode(0);
 
     expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Failed);
+});
+
+/**
+ * Resume must not undo the hold.
+ *
+ * The reaper stops a mid-print card and pauses the batch. Resume requeues
+ * failed jobs, which is right for a card that never printed and wrong for one
+ * sitting in the output bin -- and it was quietly doing both.
+ */
+it('does not requeue a held card when the batch resumes', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+    $batch->fresh()->resume();
+
+    expect($job->fresh()->status)->not->toBe(PrintJobStatusEnum::Pending);
+});
+
+it('still requeues an ordinary failure when the batch resumes', function () {
+    $batch = leaseBatch();
+    $job = $batch->printJobs()->orderBy('sequence')->first();
+    $job->claim(Machine::factory()->create(), 180);
+    $job->fresh()->markFailed('the spooler refused it');
+
+    $batch->fresh()->resume();
+
+    expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Pending);
+});
+
+it('lets the operator say the card is in the bin', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    $job->fresh()->confirmCardExists();
+
+    expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Printed)
+        ->and($job->fresh()->completion_source)->toBe(PrintCompletionSourceEnum::Recovered)
+        ->and($job->fresh()->card_may_exist)->toBeFalse();
+});
+
+it('lets the operator say there is no card and print it', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    $job->fresh()->requeueDespiteCard();
+
+    expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Pending)
+        ->and($job->fresh()->card_may_exist)->toBeFalse();
+});
+
+it('serves the card again only once the operator has asked for it', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+    $batch->fresh()->resume();
+
+    expect($batch->fresh()->claimNextJob(Machine::factory()->create())?->id)->not->toBe($job->id);
+
+    $job->fresh()->requeueDespiteCard();
+
+    expect($batch->fresh()->claimNextJob(Machine::factory()->create())?->id)->toBe($job->id);
 });

--- a/tests/Feature/Printing/LeaseExpiryTest.php
+++ b/tests/Feature/Printing/LeaseExpiryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Domain\Printing\Models\PrintBatch;
+use App\Domain\Printing\Models\Printer;
+use App\Enum\PrintBatchStatusEnum;
+use App\Enum\PrintJobStatusEnum;
+use App\Models\Badge\Badge;
+use App\Models\Machine;
+
+/**
+ * What a lapsed agent lease means depends on how far the card had got.
+ *
+ * Closing the agent mid-batch used to hand the in-flight card straight back to
+ * the queue, so restarting printed a second copy of a card already sitting in
+ * the output bin -- and could do it up to max-attempts times.
+ */
+function leaseBatch(int $cards = 3): PrintBatch
+{
+    $printer = Printer::factory()->badge()->create();
+    $batch = PrintBatch::build('Friday', Badge::factory()->withPrintFile()->count($cards)->create(), $printer);
+    $batch->transitionTo(PrintBatchStatusEnum::Ready);
+    $batch->transitionTo(PrintBatchStatusEnum::Printing);
+
+    return $batch->fresh();
+}
+
+function expiredJob(PrintBatch $batch, PrintJobStatusEnum $status)
+{
+    $job = $batch->printJobs()->orderBy('sequence')->first();
+    $job->claim(Machine::factory()->create(), 180);
+
+    if ($status === PrintJobStatusEnum::Printing) {
+        $job->fresh()->transitionTo(PrintJobStatusEnum::Printing);
+    }
+
+    $job->fresh()->forceFill(['lease_expires_at' => now()->subMinutes(10)])->save();
+
+    return $job->fresh();
+}
+
+it('requeues a claimed card, because nothing reached the printer', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Queued);
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Pending)
+        ->and($batch->fresh()->status)->toBe(PrintBatchStatusEnum::Printing);
+});
+
+it('does not requeue a card that was already printing', function () {
+    // The artwork went to the spooler. A card may be in the bin, and printing
+    // it again is a duplicate somebody has to spot by hand.
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    expect($job->fresh()->status)->not->toBe(PrintJobStatusEnum::Pending);
+});
+
+it('stops the batch so a person can look in the output bin', function () {
+    $batch = leaseBatch();
+    expiredJob($batch, PrintJobStatusEnum::Printing);
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    expect($batch->fresh()->status)->toBe(PrintBatchStatusEnum::Paused);
+});
+
+it('says plainly that the card may already exist', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    expect($job->fresh()->error_message)->toContain('may already be in the output bin');
+});
+
+it('never serves a mid-print card to another agent', function () {
+    // The actual duplicate: reap, then let an agent claim from the batch again.
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    $next = $batch->fresh()->claimNextJob(Machine::factory()->create());
+
+    expect($next?->id)->not->toBe($job->id);
+});
+
+it('still fails a claimed card that has been round too many times', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Queued);
+    $job->forceFill(['attempt_count' => 3])->save();
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Failed);
+});

--- a/tests/Feature/Printing/PrintBatchClaimTest.php
+++ b/tests/Feature/Printing/PrintBatchClaimTest.php
@@ -79,9 +79,9 @@ it('sets a lease and counts the attempt when claiming', function () {
 it('returns an abandoned job to the queue when its lease expires', function () {
     [$batch] = batchWithJobs(1);
     $job = $batch->claimNextJob(Machine::factory()->create());
-    $job->markPrinting();
 
-    // The agent dies here: no heartbeat, no completion, nothing.
+    // The agent dies here: no heartbeat, no completion, nothing. Claimed but
+    // never started, so no card exists and requeueing costs nothing.
     $job->update(['lease_expires_at' => now()->subMinute()]);
 
     $this->artisan('printing:reap-leases')->assertSuccessful();
@@ -89,6 +89,21 @@ it('returns an abandoned job to the queue when its lease expires', function () {
     expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Pending)
         ->and($job->fresh()->processing_machine_id)->toBeNull()
         ->and($job->fresh()->attempt_count)->toBe(1);
+});
+
+it('holds a job that died mid-print instead of queueing it again', function () {
+    // This test used to assert the opposite, and the opposite is what printed
+    // duplicates: once markPrinting() has run the artwork is with the spooler
+    // and a card may be in the bin. Only a person can tell.
+    [$batch] = batchWithJobs(1);
+    $job = $batch->claimNextJob(Machine::factory()->create());
+    $job->markPrinting();
+
+    $job->update(['lease_expires_at' => now()->subMinute()]);
+
+    $this->artisan('printing:reap-leases')->assertSuccessful();
+
+    expect($job->fresh()->status)->not->toBe(PrintJobStatusEnum::Pending);
 });
 
 it('fails a job and pauses its batch once attempts are exhausted', function () {


### PR DESCRIPTION
Four commits on top of `main`, none of which are the print-queue rework (that went in with #158).

## Badge verification at the POS

New `/pos/verification` screen and `BadgeVerificationController`: a printed card is checked off against the job that produced it, so a run cannot be filed as done while a card is missing or wrong. Reachable from the dashboard and the shortcut list.

## Cards are no longer reprinted after an agent restart

The agent used to re-claim work it had already put through the printer when the Windows host came back, so a restart mid-run produced duplicate cards.

- `print_jobs.card_may_exist` (new migration) records that a card may physically exist for a job even when nothing confirmed it printed.
- `ReapPrintJobLeases` and `PrintJob` honour that flag instead of blindly returning the job to the queue.
- `PrintCompletionSourceEnum` gains the cases that distinguish those outcomes.
- Agent side: `worker.py` / `api.py` report the state, covered by `test_reprint_after_restart.py`.

## Select all matching, on the badge print list

The bulk print selection can take every badge matching the current filter rather than only the rows on screen.

## Tests

`BadgeVerificationTest`, `LeaseExpiryTest`, `test_reprint_after_restart.py`, plus updates to `PrintBatchClaimTest` and `BadgesTest`. Full suite green: 1245 passed, 10 skipped.
