### PR TITLE
Reprint guard and select all matching

### DIFF
--- a/app/Console/Commands/ReapPrintJobLeases.php
+++ b/app/Console/Commands/ReapPrintJobLeases.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Domain\Printing\Models\PrintJob;
+use App\Enum\PrintJobStatusEnum;
 use Illuminate\Console\Command;
 
 /**
@@ -15,6 +16,19 @@ use Illuminate\Console\Command;
  *
  * Jobs that have been attempted too many times are failed instead of looping,
  * which pauses their batch and puts the problem in front of a human.
+ *
+ * What a lapsed lease means depends on how far the job had got, and the two
+ * cases are not interchangeable:
+ *
+ * - Queued: claimed, but nothing has reached the printer. No card exists, so
+ *   requeueing is free and another agent can pick it up.
+ * - Printing: the artwork went to the spooler. A card may well be sitting in
+ *   the output bin already, and the agent died before it could say so.
+ *   Requeueing that prints a second copy of a card somebody has in their hand.
+ *
+ * Printing therefore stops and asks. Closing the agent mid-batch used to hand
+ * the in-flight card straight back to the queue, so restarting reprinted a card
+ * that had already come out -- up to max-attempts times.
  */
 class ReapPrintJobLeases extends Command
 {
@@ -37,8 +51,23 @@ class ReapPrintJobLeases extends Command
         $requeued = 0;
         $failed = 0;
 
+        $held = 0;
+
         foreach ($expired as $job) {
             $age = $job->lease_expires_at->diffForHumans();
+
+            // Mid-card when the agent went quiet. Only a person can see whether
+            // the card is in the bin, so the batch stops rather than guessing.
+            if ($job->status === PrintJobStatusEnum::Printing) {
+                $job->holdForOperator(
+                    "Agent stopped responding while this card was printing (lease expired {$age}). "
+                    .'The card may already be in the output bin. Check before reprinting.'
+                );
+                $this->warn("Job #{$job->id}: was mid-print, batch paused for a human.");
+                $held++;
+
+                continue;
+            }
 
             if ($job->attempt_count >= $maxAttempts) {
                 $job->markFailed("Agent stopped responding after {$job->attempt_count} attempts (lease expired {$age}).");
@@ -53,7 +82,7 @@ class ReapPrintJobLeases extends Command
             $requeued++;
         }
 
-        $this->info("Requeued {$requeued}, failed {$failed}.");
+        $this->info("Requeued {$requeued}, failed {$failed}, held for a human {$held}.");
 
         return self::SUCCESS;
     }

--- a/app/Domain/Printing/Models/PrintBatch.php
+++ b/app/Domain/Printing/Models/PrintBatch.php
@@ -434,7 +434,15 @@ class PrintBatch extends Model
     {
         $requeued = 0;
 
-        foreach ($this->printJobs()->where('status', PrintJobStatusEnum::Failed)->get() as $job) {
+        // Deliberately skips jobs whose card may physically exist. Those need a
+        // person to look in the output bin, and requeueing them is exactly the
+        // duplicate this whole path was producing.
+        $failed = $this->printJobs()
+            ->where('status', PrintJobStatusEnum::Failed)
+            ->where('card_may_exist', false)
+            ->get();
+
+        foreach ($failed as $job) {
             if ($job->requeue()) {
                 $requeued++;
             }

--- a/app/Domain/Printing/Models/PrintJob.php
+++ b/app/Domain/Printing/Models/PrintJob.php
@@ -26,7 +26,7 @@ class PrintJob extends Model
     protected $fillable = [
         'printer_id', 'print_batch_id', 'sequence', 'printable_type', 'printable_id',
         'type', 'status', 'file', 'priority', 'retry_count', 'retry_of',
-        'processing_machine_id', 'attempt_count', 'lease_expires_at',
+        'processing_machine_id', 'attempt_count', 'lease_expires_at', 'card_may_exist',
         'completion_source', 'verified_print_at', 'verification_source', 'verified_by_id',
         'firmware_job_id', 'firmware_job_uuid', 'error_message',
         'printed_at', 'queued_at', 'started_at', 'failed_at',
@@ -43,6 +43,7 @@ class PrintJob extends Model
         'started_at' => 'datetime',
         'failed_at' => 'datetime',
         'lease_expires_at' => 'datetime',
+        'card_may_exist' => 'boolean',
         'verified_print_at' => 'datetime',
         'type' => PrintJobTypeEnum::class,
         'status' => PrintJobStatusEnum::class,
@@ -451,6 +452,56 @@ class PrintJob extends Model
         $this->batch?->recalculateCounters();
 
         return $updated;
+    }
+
+    /**
+     * Hold a job whose card may physically exist.
+     *
+     * The agent went quiet mid-print: the artwork reached the spooler and a
+     * card may be in the output bin, but nothing confirmed it. Failing the job
+     * pauses the batch so a person looks, and the flag stops Resume quietly
+     * requeueing it -- which is what printed a second copy of a card somebody
+     * already had in their hand.
+     */
+    public function holdForOperator(string $reason): bool
+    {
+        $this->forceFill(['card_may_exist' => true])->saveQuietly();
+
+        return $this->markFailed($reason);
+    }
+
+    /**
+     * The operator looked in the bin and the card is there.
+     *
+     * Recorded as recovered rather than as a fresh confirmation: the evidence
+     * is a person's eyes, after the fact.
+     */
+    public function confirmCardExists(): bool
+    {
+        $this->forceFill(['card_may_exist' => false])->saveQuietly();
+
+        if ($this->status === PrintJobStatusEnum::Failed) {
+            $this->transitionTo(PrintJobStatusEnum::Retrying);
+            $this->transitionTo(PrintJobStatusEnum::Queued);
+            $this->transitionTo(PrintJobStatusEnum::Printing);
+        }
+
+        $done = $this->markPrinted(PrintCompletionSourceEnum::Recovered);
+
+        $this->batch?->recalculateCounters();
+        $this->batch?->completeIfFinished();
+
+        return $done;
+    }
+
+    /**
+     * The operator looked and there is no card. Print it after all.
+     */
+    public function requeueDespiteCard(): bool
+    {
+        $this->forceFill(['card_may_exist' => false])->saveQuietly();
+
+        return $this->requeue();
     }
 
     /**

--- a/app/Enum/PrintCompletionSourceEnum.php
+++ b/app/Enum/PrintCompletionSourceEnum.php
@@ -27,6 +27,17 @@ enum PrintCompletionSourceEnum: string
     /** A human declared it done, typically after clearing a fault by hand. */
     case Operator = 'operator';
 
+    /**
+     * The agent's own records said this card had already printed here.
+     *
+     * Written when a job comes back after its lease lapsed -- the agent was
+     * closed or the host rebooted mid-run -- and the station's local store
+     * shows the card was already confirmed. The evidence is real but second
+     * hand, so it is recorded as its own source rather than dressed up as a
+     * fresh firmware confirmation.
+     */
+    case Recovered = 'recovered';
+
     public function isAuthoritative(): bool
     {
         return $this === self::Firmware;
@@ -38,6 +49,7 @@ enum PrintCompletionSourceEnum: string
             self::Firmware => 'Confirmed by printer',
             self::SpoolerOnly => 'Spooler only',
             self::Operator => 'Marked done by staff',
+            self::Recovered => 'Recovered from the agent after a restart',
         };
     }
 }

--- a/app/Http/Controllers/Manage/BadgeController.php
+++ b/app/Http/Controllers/Manage/BadgeController.php
@@ -306,6 +306,55 @@ class BadgeController extends Controller
      */
     private function table(Request $request, EventScope $scope): array
     {
+        return $this->tableBuilder($scope)->toArray($request);
+    }
+
+    /**
+     * Every badge the given filters, search and event scope match, capped.
+     *
+     * The bulk print's "select all matching" resolves through here rather than through a
+     * list of ids from the browser: the page holds twenty-five rows and the operator
+     * asked for the thousand behind them. Built from the same Table as the list, so the
+     * set queued is by construction the set that was on screen - a second query written
+     * to look like the list's is a second query that can drift from it.
+     *
+     * @return array<int, int|string>
+     */
+    public function matchingIds(Request $request, EventScope $scope, int $limit): array
+    {
+        Gate::authorize('viewAny', Badge::class);
+
+        return $this->tableBuilder($scope)->matchingIds($this->listRequest($request), $limit);
+    }
+
+    /**
+     * The bulk POST's `query` field, read back as the GET the list was drawn by.
+     *
+     * The client forwards the list's own query string verbatim instead of rebuilding
+     * `filter[...]` as nested form data: it is the exact string that produced the page, so
+     * the set queued cannot drift from the set on screen, and it is parsed here by the
+     * same rules that read it off a GET. Only the narrowing keys are read - Table ignores
+     * sort and page when resolving a set - and nothing in it can widen the event scope,
+     * which is session state and not in the query at all.
+     */
+    private function listRequest(Request $request): Request
+    {
+        $query = (string) $request->input('query', '');
+
+        if ($query === '') {
+            return $request;
+        }
+
+        parse_str($query, $params);
+
+        return Request::create('/', 'GET', is_array($params) ? $params : []);
+    }
+
+    /**
+     * The list table, before it is asked for a page or for a set of ids.
+     */
+    private function tableBuilder(EventScope $scope): Table
+    {
         return Table::make($this->query($scope))
             ->name('badges')
             ->columns($this->columns())
@@ -341,18 +390,23 @@ class BadgeController extends Controller
             // deliberately no bulk delete, no export and no dissociate, because
             // the old badge list passes bulkActions() an explicit array.
             //
-            // The selection keeps ->selectCurrentPageOnly() semantics for free: DataTable
-            // derives it from the current page's rows and prunes it on every reload, so it
-            // cannot cross a page. That cap is deliberate, not accidental, and
-            // the bulk print inherits it.
+            // The tick boxes keep ->selectCurrentPageOnly() semantics for free: DataTable
+            // derives the selection from the current page's rows and prunes it on every
+            // reload, so ticking cannot cross a page.
+            //
+            // The bulk print is the one action that may go past it, through
+            // `all: true` rather than through the boxes: a print run is the whole of what
+            // the filter matches - every unprinted badge approved since the last run - and
+            // ticking a thousand cards twenty-five at a time is not a workflow. The
+            // fulfillment write stays page-only; it bypasses the state machine, and doing
+            // that to an unseen thousand rows is a different order of mistake.
             ->bulkActions(array_values(array_filter([
                 BadgePrintController::bulkAction(),
                 self::bulkStatusAction(),
             ])))
             // ListBadges offers a CreateAction labelled `New badge`. It is not ported: the
             // page it opens has never been able to save.
-            ->pageActions([])
-            ->toArray($request);
+            ->pageActions([]);
     }
 
     /**

--- a/app/Http/Controllers/Manage/BadgePrintController.php
+++ b/app/Http/Controllers/Manage/BadgePrintController.php
@@ -13,6 +13,7 @@ use App\Http\Requests\Manage\BadgePrintRequest;
 use App\Models\Badge\Badge;
 use App\Models\Badge\State_Fulfillment\Processing;
 use App\Support\Manage\Action;
+use App\Support\Manage\EventScope;
 use App\Support\Manage\Status;
 use App\Support\Manage\Toast;
 use Carbon\Carbon;
@@ -87,6 +88,16 @@ class BadgePrintController extends Controller
     private const NOTHING_QUEUED = 'Nothing was queued';
 
     /**
+     * How many badges one "select all matching" may queue.
+     *
+     * High enough that no real filter reaches it - the whole convention is a few thousand
+     * cards and a run is a slice of that - and low enough that a filter cleared by
+     * accident cannot commit the entire table to a printer in one click. When it bites,
+     * the toast says so; see bulk().
+     */
+    private const SELECT_ALL_CAP = 2000;
+
+    /**
      * `printBadge`, the row action.
      *
      * The request does not move the badge to Processing, and must not. That transition is
@@ -135,16 +146,31 @@ class BadgePrintController extends Controller
     /**
      * `printBadgeBulk`, the bulk action.
      *
-     * The selection can never cross a page, which is `->selectCurrentPageOnly()` and a
-     * deliberate operational cap the panel keeps.
+     * Two selections reach here. The tick boxes send `ids` and cannot cross a page, which
+     * is `->selectCurrentPageOnly()` and a cap the panel keeps. `all: true` sends no ids
+     * at all and means "every badge the list's current filter matches", resolved by
+     * BadgeController against the same Table the page was drawn from, so what is queued is
+     * by construction what the operator was looking at. That is the run a print session
+     * actually is: everything approved since the last cutoff, not twenty-five of it.
+     *
+     * `all` is capped at SELECT_ALL_CAP and the operator is told when the cap bit. A run
+     * silently trimmed to the cap would report as the whole of the filter and the
+     * remainder would be found missing at the desk, which is precisely the failure the
+     * verification screen exists to catch.
      *
      * The badges are read in a single query ordered by id, only so the request is
      * deterministic. The print order is `PrintBatch::build()`'s and nothing here competes
      * with it.
      */
-    public function bulk(BadgePrintRequest $request): RedirectResponse
+    public function bulk(BadgePrintRequest $request, BadgeController $list, EventScope $scope): RedirectResponse
     {
-        $badges = Badge::whereIn('id', $request->validated('ids'))
+        $selectAll = (bool) $request->validated('all', false);
+
+        $ids = $selectAll
+            ? $list->matchingIds($request, $scope, self::SELECT_ALL_CAP)
+            : $request->validated('ids', []);
+
+        $badges = Badge::whereIn('id', $ids)
             ->orderBy('id')
             ->get();
 
@@ -165,7 +191,9 @@ class BadgePrintController extends Controller
 
         Toast::flashSuccess(
             $badges->count() === 1 ? 'Badge queued for printing' : 'Badges queued for printing',
-            $this->queuedBody($batch),
+            $this->queuedBody($batch).($selectAll && count($ids) >= self::SELECT_ALL_CAP
+                ? ' Capped at '.self::SELECT_ALL_CAP.' badges: narrow the filter and run it again for the rest.'
+                : ''),
         );
 
         return $this->backWithCutoff($badges);
@@ -307,6 +335,9 @@ class BadgePrintController extends Controller
         return Action::post('printBadgeBulk', self::BULK_LABEL, route('admin.badges.bulk.print'))
             ->icon('printer')
             ->tone(Status::WARN)
+            // The one bulk action that understands "everything the filter matches"; the
+            // client offers that affordance only for actions carrying this flag.
+            ->selectAll()
             ->confirm(self::BULK_HEADING, self::BULK_DESCRIPTION)
             ->fields([
                 [

--- a/app/Http/Controllers/PrintAgent/AgentJobController.php
+++ b/app/Http/Controllers/PrintAgent/AgentJobController.php
@@ -112,7 +112,7 @@ class AgentJobController extends AgentController
     public function printed(Request $request, int $job): JsonResponse
     {
         $data = $request->validate([
-            'completion_source' => ['required', 'string', 'in:firmware,spooler_only,operator'],
+            'completion_source' => ['required', 'string', 'in:firmware,spooler_only,operator,recovered'],
             'firmware_job_id' => 'nullable|string|max:64',
             'firmware_job_uuid' => 'nullable|string|max:64',
         ]);

--- a/app/Http/Requests/Manage/BadgePrintRequest.php
+++ b/app/Http/Requests/Manage/BadgePrintRequest.php
@@ -42,8 +42,17 @@ class BadgePrintRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'ids' => ['required', 'array'],
+            // Either an explicit selection, or `all` - "every badge the list's current
+            // filter matches", which the server resolves. Never both: `ids` is what the
+            // tick boxes send and is ignored when `all` is set.
+            'all' => ['sometimes', 'boolean'],
+            'ids' => ['required_without:all', 'array'],
             'ids.*' => ['integer'],
+            // The list's own query string, forwarded verbatim by the bulk bar and parsed
+            // back into filters by BadgeController. Only read when `all` is set.
+            // Nullable: an unfiltered list forwards an empty string, which the framework
+            // has already converted to null by the time the rules run.
+            'query' => ['sometimes', 'nullable', 'string', 'max:2000'],
             'printer_id' => ['required', 'integer', Rule::in(BadgePrintController::printerIds())],
         ];
     }
@@ -54,6 +63,7 @@ class BadgePrintRequest extends FormRequest
     public function messages(): array
     {
         return [
+            'ids.required_without' => 'Select the badges to print, or select everything the filter matches.',
             'printer_id.required' => 'Select a printer to send these badges to.',
             'printer_id.in' => 'That printer is not an active badge printer.',
         ];

--- a/app/Support/Manage/Action.php
+++ b/app/Support/Manage/Action.php
@@ -39,6 +39,8 @@ final class Action implements Arrayable
 
     private bool $newTab = false;
 
+    private bool $selectAll = false;
+
     private function __construct(
         public readonly string $name,
         public readonly string $label,
@@ -139,6 +141,22 @@ final class Action implements Arrayable
     }
 
     /**
+     * This action understands `all: true` - "every record the current filter matches",
+     * resolved server side - as well as a list of ids.
+     *
+     * Opt-in per action, and the client only offers the affordance for actions carrying
+     * this flag. An endpoint that reads `ids` and ignores `all` would otherwise answer a
+     * "select all 1,204" by acting on the 25 rows that happen to be on screen, which is
+     * the one outcome worse than not offering it.
+     */
+    public function selectAll(bool $selectAll = true): self
+    {
+        $this->selectAll = $selectAll;
+
+        return $this;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function toArray(): array
@@ -154,6 +172,7 @@ final class Action implements Arrayable
             'fields' => $this->fields === [] ? null : $this->fields,
             'disabledReason' => $this->disabledReason,
             'newTab' => $this->newTab,
+            'selectAll' => $this->selectAll,
         ];
     }
 }

--- a/app/Support/Manage/Table.php
+++ b/app/Support/Manage/Table.php
@@ -244,6 +244,36 @@ final class Table
     }
 
     /**
+     * The keys of every record the current tab, filters and search match, ignoring
+     * pagination and sort.
+     *
+     * This is what "select all matching" resolves to. It is deliberately not the client's
+     * job: the browser holds one page of ids, and a selection that means "everything the
+     * filter matches" can only be answered by the same narrowing that produced the page.
+     * Sort is skipped because a set has no order, and the print pipeline imposes its own.
+     *
+     * `$limit` is a real cap, not a guess: the caller is expected to compare what comes
+     * back against it and tell the operator when the run was trimmed, because a silently
+     * truncated "all" reads as "all".
+     *
+     * The request is a POST here, so `rememberReturnUrl()` is not called and the list URL
+     * this action came from stays remembered.
+     *
+     * @return array<int, int|string>
+     */
+    public function matchingIds(Request $request, int $limit): array
+    {
+        $this->resolveTab($request)?->applyTo($this->query);
+        $this->applyFilters($this->resolveFilterValues($request));
+        $this->applySearch(trim((string) $request->input('search', '')));
+
+        return $this->query
+            ->limit($limit)
+            ->pluck($this->query->getModel()->getQualifiedKeyName())
+            ->all();
+    }
+
+    /**
      * Remembers the list URL, query string and all, so a save can come back to it.
      *
      * Tab, filters, search, sort and page live entirely in the URL, so a controller that

--- a/database/migrations/2026_08_08_180000_add_card_may_exist_to_print_jobs_table.php
+++ b/database/migrations/2026_08_08_180000_add_card_may_exist_to_print_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Support\Migrations\SchemaGuard;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Mark the jobs where a card may physically exist but nothing recorded it.
+ *
+ * Happens when an agent dies mid-print: the artwork reached the spooler, a card
+ * may be in the output bin, and the confirmation never arrived. The job is
+ * failed so a human looks at it, but "failed" alone is indistinguishable from a
+ * card that never printed -- and Resume requeues those, which printed a second
+ * copy of a card somebody already had in their hand.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('print_jobs', function (Blueprint $table) {
+            if (SchemaGuard::missingColumn('print_jobs', 'card_may_exist')) {
+                $table->boolean('card_may_exist')->default(false)->after('completion_source');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('print_jobs', function (Blueprint $table) {
+            if (SchemaGuard::hasColumn('print_jobs', 'card_may_exist')) {
+                $table->dropColumn('card_may_exist');
+            }
+        });
+    }
+};

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -42,6 +42,18 @@ costs nothing but trouble. See `App\Badges\ImagePreparer`.
 
 ## Starting a run
 
+**What goes into a run.** The badge list's tick boxes cannot cross a page, which is deliberate for
+every bulk action in `/admin`. The print run is the one exception: with the page fully ticked, the
+bulk bar offers **Select all N matching the filter**, and the action then posts `all: true` plus the
+list's own query string instead of a list of ids. `BadgeController::matchingIds()` re-narrows through
+the same `Table` that drew the page, so what is queued is by construction what was on screen. The
+event scope rides in the session and cannot be widened by the forwarded query.
+
+A run started that way is capped at 2000 badges and the toast says so when the cap bites, because a
+run silently trimmed to a cap reports as the whole filter and the remainder is only discovered
+missing at the desk. Only actions declaring `Action::selectAll()` are offered past the page: the bulk
+fulfillment write bypasses the state machine and stays page-only.
+
 Pressing Print does not print, and does not render. The request opens an empty `Draft` batch and
 dispatches `PrepareBadgePrintBatchJob` on the `badge-render` queue; everything expensive happens
 there. The operator gets the batch back immediately and watches it turn from preparing to ready.

--- a/print-agent/agent/api.py
+++ b/print-agent/agent/api.py
@@ -43,6 +43,11 @@ COMPLETION_FIRMWARE = "firmware"
 COMPLETION_SPOOLER_ONLY = "spooler_only"
 COMPLETION_OPERATOR = "operator"
 
+# The agent's own records showed the card had already printed here, on a job the
+# server handed back after a lease lapsed. Second-hand evidence, so it is named
+# rather than passed off as a fresh firmware confirmation.
+COMPLETION_RECOVERED = "recovered"
+
 # Accepted by POST /jobs/{job}/verify. See PrintVerificationSourceEnum.
 VERIFY_CAMERA = "camera"
 VERIFY_OPERATOR = "operator"

--- a/print-agent/agent/worker.py
+++ b/print-agent/agent/worker.py
@@ -61,6 +61,7 @@ from typing import Any, Callable, Dict, List, NamedTuple, Optional
 from .api import (
     COMPLETION_FIRMWARE,
     COMPLETION_OPERATOR,
+    COMPLETION_RECOVERED,
     COMPLETION_SPOOLER_ONLY,
     VERIFY_CAMERA,
     VERIFY_OPERATOR,
@@ -686,6 +687,54 @@ class _BaseWorker:
     # Odds and ends
     # ------------------------------------------------------------------
 
+    def _already_printed(self, job_id: int) -> Optional[Outcome]:
+        """Refuse to print a card this station has already produced.
+
+        A job only comes back after its lease lapsed, which happens when the
+        agent was closed or the host rebooted mid-run. The server cannot know
+        whether a card came out -- but this station can, because it wrote down
+        how far the job got before it died.
+
+        Only `reported` and `done` count as evidence. Both are written after the
+        printer confirmed the card. `printing` is set before the artwork is
+        spooled, so it proves an attempt, not a card, and that ambiguous case is
+        left to the operator through the usual reprint question.
+
+        Returns an Outcome to hand straight back, or None to print normally.
+        """
+        try:
+            record = self.store.job(job_id)
+        except Exception:  # noqa: BLE001 - an unreadable store cannot veto a print
+            return None
+
+        if not record:
+            return None
+
+        status = (record.get("status") or "").lower()
+
+        if status not in (JOB_REPORTED, JOB_DONE):
+            return None
+
+        card = record.get("card_number") or str(job_id)
+        detail = ("Card %s already printed here; telling the server rather than "
+                  "printing it twice" % card)
+
+        self._log(detail)
+        self._progress(STEP_REPORT, DONE, "already printed")
+
+        # The server thinks this is still outstanding, so the confirmation it
+        # never received goes out again. Through the outbox, so a server that is
+        # still unreachable does not lose it a second time.
+        self._deliver(
+            OUTBOX_PRINTED,
+            {"job_id": job_id, "completion_source": COMPLETION_RECOVERED},
+            lambda: self.api.mark_printed(job_id, completion_source=COMPLETION_RECOVERED),
+        )
+
+        self.store_status(job_id, JOB_DONE)
+
+        return Outcome(PRINTED, detail, job_id)
+
     def _remember(self, job: Dict[str, Any], status: str) -> None:
         self._call(self.store.save_job, job, self.printer_name, self.batch_id, status)
 
@@ -1147,6 +1196,12 @@ class PrintWorker(_BaseWorker):
             self._reset_pipeline()
 
         self._progress(STEP_CLAIM, DONE, "card %s" % self._card_number(job))
+
+        # The server handed this back, but we may already have printed it.
+        already = self._already_printed(job_id)
+
+        if already is not None:
+            return already
 
         # Cached before anything is printed. From here on the card is committed
         # to: if the network dies we still know what we hold and what to send.

--- a/print-agent/tests/test_reprint_after_restart.py
+++ b/print-agent/tests/test_reprint_after_restart.py
@@ -1,0 +1,102 @@
+"""Closing the agent mid-batch must not reprint the card that already came out.
+
+The server hands a job back once its lease lapses, because from where it sits a
+silent agent is indistinguishable from a dead one. It cannot know whether a card
+reached the output bin. This station can: it wrote down how far the job got.
+"""
+
+import unittest
+
+import agent.worker as worker
+
+from test_worker import WorkerTestCase, job
+
+
+class AlreadyPrintedTest(WorkerTestCase):
+    def setUp(self):
+        super().setUp()
+        self.api.queue.append(job(11, "24-0031"))
+
+    def printed_but_never_reported(self):
+        """The window that produces duplicates.
+
+        The card comes out, then the confirmation cannot be delivered -- the
+        agent was closed, or the network went. The server still has the job
+        outstanding, so once the lease lapses it hands it back. The local row
+        survives as `reported`, which is the evidence this station has and the
+        server does not.
+        """
+        self.api.printed_error = worker.NetworkError("server unreachable")
+        self.build().print_next()
+
+        self.api.printed_error = None
+        self.api.printing = []
+        self.sent = []
+
+    def test_the_first_run_prints_normally(self):
+        outcome = self.build().print_next()
+
+        self.assertEqual(worker.PRINTED, outcome.kind)
+        self.assertEqual(1, len(self.sent))
+
+    def test_a_returned_job_is_not_printed_a_second_time(self):
+        self.printed_but_never_reported()
+        self.api.queue.append(job(11, "24-0031"))   # the server hands it back
+
+        self.build().print_next()
+
+        self.assertEqual([], self.sent)
+
+    def test_it_tells_the_server_the_card_exists(self):
+        # The confirmation the server never received, sent again -- otherwise
+        # the job sits pending and comes round once more.
+        self.printed_but_never_reported()
+        self.api.queue.append(job(11, "24-0031"))
+
+        self.build().print_next()
+
+        self.assertEqual(1, len(self.api.printed))
+        self.assertEqual("recovered", self.api.printed[0]["completion_source"])
+
+    def test_it_reports_the_card_as_printed_rather_than_failed(self):
+        self.printed_but_never_reported()
+        self.api.queue.append(job(11, "24-0031"))
+
+        outcome = self.build().print_next()
+
+        self.assertEqual(worker.PRINTED, outcome.kind)
+        self.assertEqual([], self.api.failed)
+
+    def test_a_card_this_station_never_printed_is_printed(self):
+        # The guard must not swallow honest work: a job with no local history
+        # is a job whose card does not exist.
+        self.api.queue.append(job(12, "24-0032"))
+        w = self.build()
+
+        w.print_next()
+        w.print_next()
+
+        self.assertEqual(2, len(self.sent))
+
+    def test_an_attempt_that_never_confirmed_is_not_treated_as_printed(self):
+        # `printing` is written before the artwork is spooled, so it proves an
+        # attempt, not a card. Reading it as evidence would skip real work.
+        self.store.save_job(job(11, "24-0031"), "ZXP9-Left", 77, worker.JOB_PRINTING)
+
+        self.build().print_next()
+
+        self.assertEqual(1, len(self.sent))
+
+    def test_an_unreadable_store_never_blocks_a_print(self):
+        class Broken:
+            def __getattr__(self, name):
+                raise RuntimeError("disk gone")
+
+        w = self.build()
+        w.store = Broken()
+
+        self.assertIsNone(w._already_printed(11))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/resources/js/Components/Manage/DataTable.vue
+++ b/resources/js/Components/Manage/DataTable.vue
@@ -167,6 +167,72 @@ const someSelected = computed(() => selected.value.length > 0 && !allSelected.va
 
 const toggleAll = () => {
   selected.value = allSelected.value ? [] : props.table.rows.map((row) => row.id);
+  allMatching.value = false;
+};
+
+/**
+ * "Everything the current filter matches", as opposed to the rows that are ticked.
+ *
+ * The browser only ever holds one page of ids, so this is a flag rather than a longer
+ * list: the action posts `all: true` plus the list's own query string, and the server
+ * resolves the set through the same Table that drew the page. Offered only by actions
+ * that declare they understand it - an endpoint reading `ids` and ignoring `all` would
+ * answer "select all 1,204" by acting on the 25 rows on screen.
+ */
+const allMatching = ref(false);
+
+const selectAllActions = computed(() => props.table.bulkActions.filter((action) => action.selectAll));
+
+const matchingTotal = computed(() => props.table.meta?.total ?? 0);
+
+/*
+ * The offer only stands over a fully ticked page with more behind it, and drops the moment
+ * the selection or what the filter matches changes: the flag means "the set I am looking
+ * at", and that set has just become a different one.
+ */
+const canSelectAllMatching = computed(
+  () => selectAllActions.value.length > 0
+    && allSelected.value
+    && matchingTotal.value > props.table.rows.length,
+);
+
+watch(
+  () => [props.table.meta?.total, props.table.search, JSON.stringify(props.table.filters ?? [])],
+  () => {
+    allMatching.value = false;
+  },
+);
+
+watch(selected, (next) => {
+  if (!next.length) {
+    allMatching.value = false;
+  }
+});
+
+/*
+ * While the whole filter is selected, only the actions that can act on it are offered.
+ * Hiding the others is the honest option: leaving them enabled would run them over the
+ * page while the bar says a thousand rows are selected.
+ */
+const offeredActions = computed(() =>
+  allMatching.value ? selectAllActions.value : props.table.bulkActions,
+);
+
+/**
+ * What a bulk action posts: the ticked ids, or the flag plus the list's own query.
+ *
+ * The query string is forwarded verbatim rather than rebuilt as nested data. It is the
+ * exact string that produced the page, so the narrowing cannot drift from what the
+ * operator is looking at, and the server parses it back with the same rules that read it
+ * off a GET. Sort and page ride along and are ignored: a set has no order and no page.
+ */
+const actionData = (action) => (allMatching.value && action.selectAll
+  ? { all: true, query: window.location.search.replace(/^\?/, '') }
+  : { ids: selected.value });
+
+const clearSelection = () => {
+  selected.value = [];
+  allMatching.value = false;
 };
 
 /*
@@ -259,18 +325,40 @@ const open = (row, event) => {
       v-if="selected.length && table.bulkActions.length"
       class="flex h-10 items-center gap-2 border-b border-hairline bg-mg-surface-2 px-3"
     >
-      <span class="text-[12px] text-fg-2">{{ selected.length }} selected</span>
+      <span class="text-[12px] text-fg-2">
+        {{ allMatching ? `all ${matchingTotal} matching selected` : `${selected.length} selected` }}
+      </span>
       <ActionButton
-        v-for="action in table.bulkActions"
+        v-for="action in offeredActions"
         :key="action.name"
         :action="action"
-        :data="{ ids: selected }"
-        @completed="selected = []"
+        :data="actionData(action)"
+        @completed="clearSelection"
       />
+
+      <!-- Past the page. Shown only over a fully ticked page with more behind it, so it
+           never appears while the operator is picking individual rows. -->
+      <button
+        v-if="canSelectAllMatching && !allMatching"
+        type="button"
+        class="text-[12px] font-medium text-state-live underline-offset-2 hover:underline"
+        @click="allMatching = true"
+      >
+        Select all {{ matchingTotal }} matching the filter
+      </button>
+      <button
+        v-else-if="allMatching"
+        type="button"
+        class="text-[12px] text-fg-3 transition-colors hover:text-fg-1"
+        @click="allMatching = false"
+      >
+        Just this page
+      </button>
+
       <button
         type="button"
         class="ml-auto text-[12px] text-fg-3 transition-colors hover:text-fg-1"
-        @click="selected = []"
+        @click="clearSelection"
       >
         Clear
       </button>

--- a/tests/Feature/Manage/BadgePrintTest.php
+++ b/tests/Feature/Manage/BadgePrintTest.php
@@ -306,6 +306,104 @@ test('the print order is the batch\'s own, not a second one layered on top', fun
         ->toBe([$spare->id, $main->id, $later->id]);
 });
 
+/*
+ * "Select all matching": the run is the whole of what the filter matches, resolved on the
+ * server. The browser holds one page of ids and the operator is asking for the thousand
+ * behind them, so anything the client could send is the wrong answer.
+ */
+
+test('select all matching queues every badge the filter matches, not the ids posted', function () {
+    $first = ($this->badge)('0100-1');
+    $second = ($this->badge)('0101-1');
+    $third = ($this->badge)('0102-1');
+
+    actingAs($this->admin)->post(route('admin.badges.bulk.print'), [
+        'all' => true,
+        // Deliberately naming one badge: `all` means the filter, and `ids` is ignored.
+        'ids' => [$first->id],
+        'query' => '',
+        'printer_id' => $this->printer->id,
+    ])->assertRedirect()->assertSessionHasNoErrors();
+
+    expect(PrintBatch::sole()->printJobs()->pluck('printable_id')->sort()->values()->all())
+        ->toBe(collect([$first->id, $second->id, $third->id])->sort()->values()->all());
+});
+
+test('select all matching narrows by the filters the list was drawn with', function () {
+    $pending = ($this->badge)('0100-1');
+    ($this->badge)('0101-1', ['status_fulfillment' => 'picked_up']);
+
+    actingAs($this->admin)->post(route('admin.badges.bulk.print'), [
+        'all' => true,
+        'query' => http_build_query(['filter' => ['status_fulfillment' => ['pending']]]),
+        'printer_id' => $this->printer->id,
+    ])->assertRedirect()->assertSessionHasNoErrors();
+
+    expect(PrintBatch::sole()->printJobs()->pluck('printable_id')->all())->toBe([$pending->id]);
+});
+
+test('select all matching stays inside the selected event', function () {
+    $mine = ($this->badge)('0100-1');
+
+    $otherEvent = Event::factory()->create(['name' => 'Eurofurence 28', 'starts_at' => now()->subYear()]);
+    $stranger = User::factory()->create();
+    EventUser::factory()->create([
+        'user_id' => $stranger->id,
+        'event_id' => $otherEvent->id,
+        'attendee_id' => '0900',
+    ]);
+    Badge::factory()->withPrintFile()->create([
+        'custom_id' => '0900-1',
+        'status_fulfillment' => 'pending',
+        'status_payment' => 'paid',
+        'fursuit_id' => Fursuit::factory()->create([
+            'event_id' => $otherEvent->id,
+            'user_id' => $stranger->id,
+            'species_id' => Species::firstOrCreate(['name' => 'Blue Fox'], ['type' => 'canine', 'checked' => true])->id,
+        ])->id,
+    ]);
+
+    // The event scope is session state, not something the forwarded query can widen.
+    actingAs($this->admin)
+        ->withSession([EventScope::SESSION_ID => $this->event->id, EventScope::SESSION_CHOSEN => true])
+        ->post(route('admin.badges.bulk.print'), [
+            'all' => true,
+            'query' => '',
+            'printer_id' => $this->printer->id,
+        ])->assertRedirect()->assertSessionHasNoErrors();
+
+    expect(PrintBatch::sole()->printJobs()->pluck('printable_id')->all())->toBe([$mine->id]);
+});
+
+test('select all matching needs no ids at all', function () {
+    ($this->badge)('0100-1');
+
+    actingAs($this->admin)->post(route('admin.badges.bulk.print'), [
+        'all' => true,
+        'printer_id' => $this->printer->id,
+    ])->assertRedirect()->assertSessionHasNoErrors();
+
+    expect(PrintBatch::count())->toBe(1);
+});
+
+test('a bulk print with neither ids nor all is a validation error', function () {
+    actingAs($this->admin)->post(route('admin.badges.bulk.print'), [
+        'printer_id' => $this->printer->id,
+    ])->assertSessionHasErrors('ids');
+
+    expect(PrintBatch::count())->toBe(0);
+});
+
+test('only the print action offers to go past the page', function () {
+    ($this->badge)();
+
+    $props = ($this->scoped)()->get(route('admin.badges.index'))->viewData('page')['props'];
+
+    // The fulfillment write bypasses the state machine, so it stays page-only.
+    expect(collect($props['bulkActions'])->firstWhere('name', 'printBadgeBulk')['selectAll'])->toBeTrue()
+        ->and(collect($props['bulkActions'])->firstWhere('name', 'setFulfillmentStatus')['selectAll'])->toBeFalse();
+});
+
 test('the bulk action requires a printer and queues nothing without one', function () {
     $badge = ($this->badge)();
 

--- a/tests/Feature/Printing/LeaseExpiryTest.php
+++ b/tests/Feature/Printing/LeaseExpiryTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Domain\Printing\Models\PrintBatch;
+use App\Domain\Printing\Models\Printer;
+use App\Enum\PrintBatchStatusEnum;
+use App\Enum\PrintCompletionSourceEnum;
+use App\Enum\PrintJobStatusEnum;
+use App\Models\Badge\Badge;
+use App\Models\Machine;
+
+/**
+ * What a lapsed agent lease means depends on how far the card had got.
+ *
+ * Closing the agent mid-batch used to hand the in-flight card straight back to
+ * the queue, so restarting printed a second copy of a card already sitting in
+ * the output bin -- and could do it up to max-attempts times.
+ */
+function leaseBatch(int $cards = 3): PrintBatch
+{
+    $printer = Printer::factory()->badge()->create();
+    $batch = PrintBatch::build('Friday', Badge::factory()->withPrintFile()->count($cards)->create(), $printer);
+    $batch->transitionTo(PrintBatchStatusEnum::Ready);
+    $batch->transitionTo(PrintBatchStatusEnum::Printing);
+
+    return $batch->fresh();
+}
+
+function expiredJob(PrintBatch $batch, PrintJobStatusEnum $status)
+{
+    $job = $batch->printJobs()->orderBy('sequence')->first();
+    $job->claim(Machine::factory()->create(), 180);
+
+    if ($status === PrintJobStatusEnum::Printing) {
+        $job->fresh()->transitionTo(PrintJobStatusEnum::Printing);
+    }
+
+    $job->fresh()->forceFill(['lease_expires_at' => now()->subMinutes(10)])->save();
+
+    return $job->fresh();
+}
+
+it('requeues a claimed card, because nothing reached the printer', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Queued);
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Pending)
+        ->and($batch->fresh()->status)->toBe(PrintBatchStatusEnum::Printing);
+});
+
+it('does not requeue a card that was already printing', function () {
+    // The artwork went to the spooler. A card may be in the bin, and printing
+    // it again is a duplicate somebody has to spot by hand.
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    expect($job->fresh()->status)->not->toBe(PrintJobStatusEnum::Pending);
+});
+
+it('stops the batch so a person can look in the output bin', function () {
+    $batch = leaseBatch();
+    expiredJob($batch, PrintJobStatusEnum::Printing);
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    expect($batch->fresh()->status)->toBe(PrintBatchStatusEnum::Paused);
+});
+
+it('says plainly that the card may already exist', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    expect($job->fresh()->error_message)->toContain('may already be in the output bin');
+});
+
+it('never serves a mid-print card to another agent', function () {
+    // The actual duplicate: reap, then let an agent claim from the batch again.
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    $next = $batch->fresh()->claimNextJob(Machine::factory()->create());
+
+    expect($next?->id)->not->toBe($job->id);
+});
+
+it('still fails a claimed card that has been round too many times', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Queued);
+    $job->forceFill(['attempt_count' => 3])->save();
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Failed);
+});
+
+/**
+ * Resume must not undo the hold.
+ *
+ * The reaper stops a mid-print card and pauses the batch. Resume requeues
+ * failed jobs, which is right for a card that never printed and wrong for one
+ * sitting in the output bin -- and it was quietly doing both.
+ */
+it('does not requeue a held card when the batch resumes', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+    $batch->fresh()->resume();
+
+    expect($job->fresh()->status)->not->toBe(PrintJobStatusEnum::Pending);
+});
+
+it('still requeues an ordinary failure when the batch resumes', function () {
+    $batch = leaseBatch();
+    $job = $batch->printJobs()->orderBy('sequence')->first();
+    $job->claim(Machine::factory()->create(), 180);
+    $job->fresh()->markFailed('the spooler refused it');
+
+    $batch->fresh()->resume();
+
+    expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Pending);
+});
+
+it('lets the operator say the card is in the bin', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    $job->fresh()->confirmCardExists();
+
+    expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Printed)
+        ->and($job->fresh()->completion_source)->toBe(PrintCompletionSourceEnum::Recovered)
+        ->and($job->fresh()->card_may_exist)->toBeFalse();
+});
+
+it('lets the operator say there is no card and print it', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+
+    $job->fresh()->requeueDespiteCard();
+
+    expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Pending)
+        ->and($job->fresh()->card_may_exist)->toBeFalse();
+});
+
+it('serves the card again only once the operator has asked for it', function () {
+    $batch = leaseBatch();
+    $job = expiredJob($batch, PrintJobStatusEnum::Printing);
+    $this->artisan('printing:reap-leases')->assertExitCode(0);
+    $batch->fresh()->resume();
+
+    expect($batch->fresh()->claimNextJob(Machine::factory()->create())?->id)->not->toBe($job->id);
+
+    $job->fresh()->requeueDespiteCard();
+
+    expect($batch->fresh()->claimNextJob(Machine::factory()->create())?->id)->toBe($job->id);
+});

--- a/tests/Feature/Printing/PrintBatchClaimTest.php
+++ b/tests/Feature/Printing/PrintBatchClaimTest.php
@@ -79,9 +79,9 @@ it('sets a lease and counts the attempt when claiming', function () {
 it('returns an abandoned job to the queue when its lease expires', function () {
     [$batch] = batchWithJobs(1);
     $job = $batch->claimNextJob(Machine::factory()->create());
-    $job->markPrinting();
 
-    // The agent dies here: no heartbeat, no completion, nothing.
+    // The agent dies here: no heartbeat, no completion, nothing. Claimed but
+    // never started, so no card exists and requeueing costs nothing.
     $job->update(['lease_expires_at' => now()->subMinute()]);
 
     $this->artisan('printing:reap-leases')->assertSuccessful();
@@ -89,6 +89,21 @@ it('returns an abandoned job to the queue when its lease expires', function () {
     expect($job->fresh()->status)->toBe(PrintJobStatusEnum::Pending)
         ->and($job->fresh()->processing_machine_id)->toBeNull()
         ->and($job->fresh()->attempt_count)->toBe(1);
+});
+
+it('holds a job that died mid-print instead of queueing it again', function () {
+    // This test used to assert the opposite, and the opposite is what printed
+    // duplicates: once markPrinting() has run the artwork is with the spooler
+    // and a card may be in the bin. Only a person can tell.
+    [$batch] = batchWithJobs(1);
+    $job = $batch->claimNextJob(Machine::factory()->create());
+    $job->markPrinting();
+
+    $job->update(['lease_expires_at' => now()->subMinute()]);
+
+    $this->artisan('printing:reap-leases')->assertSuccessful();
+
+    expect($job->fresh()->status)->not->toBe(PrintJobStatusEnum::Pending);
 });
 
 it('fails a job and pauses its batch once attempts are exhausted', function () {


### PR DESCRIPTION
Two changes on top of `main`. No overlap with #160 (POS badge verification), which stays on its own branch.

## Stop reprinting cards after an agent restart

A restarted agent re-claimed jobs it had already put through the printer, so a Windows host coming back mid-run produced duplicate cards.

- `print_jobs.card_may_exist` (new migration) records that a card may physically exist for a job even when nothing confirmed it printed.
- `ReapPrintJobLeases` and `PrintJob` honour that flag rather than blindly returning the job to the queue; `PrintCompletionSourceEnum` carries the outcomes that distinguish those cases.
- Agent side: `worker.py` and `api.py` report the state, covered by `print-agent/tests/test_reprint_after_restart.py`.
- `LeaseExpiryTest` and `PrintBatchClaimTest` cover the Laravel half.

## Select all matching, on the badge print list

The bulk print selection can take every badge the current filter matches rather than only the rows on the page. `all: true` sends no ids and is resolved by `BadgeController` against the same Table the page was drawn from, so what is queued is by construction what the operator was looking at. Capped at `SELECT_ALL_CAP`, and the operator is told when the cap bit.

## Tests

Full suite green on this branch alone: 1232 passed, 10 skipped. Nothing here depends on the verification screen. The python agent test was not run locally (no pytest in this environment).
