### PR TITLE
Fix print batch retry_after

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,11 @@ BROADCAST_CONNECTION=log
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database
 
+# Seconds before a reserved job is handed to another worker, on the connection that
+# carries badge rendering. Must stay above PrepareBadgePrintBatchJob's timeout, or a
+# long run is re-served mid-render and fails as "attempted too many times".
+LONG_RUNNING_QUEUE_RETRY_AFTER=3660
+
 CACHE_STORE=database
 CACHE_PREFIX=
 

--- a/app/Jobs/Printing/GenerateBadgePrintFileJob.php
+++ b/app/Jobs/Printing/GenerateBadgePrintFileJob.php
@@ -47,6 +47,10 @@ class GenerateBadgePrintFileJob implements ShouldQueue
         public readonly bool $force = false,
         public readonly bool $ignorePrintingLock = false,
     ) {
+        // Same connection as the queue it names. `badge-render` is consumed by one
+        // supervisor on `queue.long_running`, so a render left on the default connection
+        // would sit in a queue nothing reads.
+        $this->onConnection(config('queue.long_running'));
         $this->onQueue('badge-render');
     }
 

--- a/app/Jobs/Printing/PrepareBadgePrintBatchJob.php
+++ b/app/Jobs/Printing/PrepareBadgePrintBatchJob.php
@@ -33,12 +33,21 @@ use Throwable;
  * anything a person is waiting on: a full page of unrendered badges is minutes of image
  * work. `failOnTimeout` matters more than the number - it is what gets `failed()` called,
  * and `failed()` is what puts the badges back when the worker is killed mid-render.
+ *
+ * The timeout alone is not enough, which is why this runs on `queue.long_running` rather
+ * than the default connection. `retry_after` belongs to the connection and the shared one
+ * is 90 seconds, so a run of a hundred cards became visible again long before it finished:
+ * a second worker reserved it, saw `attempts` past `tries = 1`, and failed it with
+ * "App\Jobs\Printing\PrepareBadgePrintBatchJob has been attempted too many times" - which
+ * ran `failed()`, cancelled the batch and returned the badges while the first worker was
+ * still rendering them. The long-running connection's `retry_after` sits above `$timeout`,
+ * so nothing re-serves a run that is still going.
  */
 class PrepareBadgePrintBatchJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public $timeout = 1800;
+    public $timeout = 3600;
 
     public $tries = 1;
 
@@ -53,6 +62,7 @@ class PrepareBadgePrintBatchJob implements ShouldQueue
         public readonly array $badgeIds,
         public readonly bool $autoName = true,
     ) {
+        $this->onConnection(config('queue.long_running'));
         $this->onQueue('badge-render');
     }
 

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -219,9 +219,16 @@ return [
          *
          * `tries` is 1 to match that job: a run that fails is undone and pressed again,
          * never retried underneath the operator.
+         *
+         * Its own connection too, not just its own queue. `retry_after` is per connection,
+         * and the shared one's 90 seconds is shorter than a single run: the queue handed
+         * the same job to a second worker mid-render, which failed it for exceeding
+         * `tries` and cancelled the batch out from under the run. `queue.long_running`
+         * holds the reasoning; the only rule here is that its `retry_after` stays above
+         * this `timeout`.
          */
         'badge-render-supervisor' => [
-            'connection' => 'redis',
+            'connection' => 'redis-long-running',
             'queue' => ['badge-render'],
             'balance' => 'simple',
             'autoScalingStrategy' => 'time',
@@ -230,7 +237,7 @@ return [
             'maxJobs' => 0,
             'memory' => 512,
             'tries' => 1,
-            'timeout' => 1800,
+            'timeout' => 3600,
             'nice' => 0,
         ],
     ],
@@ -253,7 +260,7 @@ return [
             // S3 bandwidth and memory for no gain.
             'badge-render-supervisor' => [
                 'maxProcesses' => 3,
-                'timeout' => 1800,
+                'timeout' => 3600,
                 'tries' => 1,
             ],
         ],
@@ -268,7 +275,7 @@ return [
             ],
             'badge-render-supervisor' => [
                 'maxProcesses' => 1,
-                'timeout' => 900,
+                'timeout' => 3600,
             ],
         ],
     ],

--- a/config/queue.php
+++ b/config/queue.php
@@ -17,6 +17,38 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Long Running Connection
+    |--------------------------------------------------------------------------
+    |
+    | Which connection carries work measured in minutes rather than seconds -
+    | today the `badge-render` lane. It exists because `retry_after` is a
+    | property of the connection, not of the queue or the job: whatever value
+    | the shared connections carry is also the point at which a job that is
+    | still running is handed to a second worker.
+    |
+    | A hundred unrendered cards is an S3 read, an image decode and an mpdf
+    | write each. On the shared connection's 90 seconds the queue re-served
+    | PrepareBadgePrintBatchJob while the first worker was still rendering; the
+    | second worker found `attempts` past `tries = 1`, failed the job with
+    | "has been attempted too many times", and its `failed()` hook cancelled the
+    | batch and returned the badges underneath the run that was still building
+    | them. So that lane gets its own connection with `retry_after` above the
+    | job timeout, and the shared ones keep recovering a lost job in 90 seconds.
+    |
+    | Resolved from the default connection so the lane exists under Horizon
+    | (redis) and under a plain `queue:work` (database) alike. `sync` and
+    | anything else falls through to itself - there is nothing to reserve.
+    |
+    */
+
+    'long_running' => env('LONG_RUNNING_QUEUE_CONNECTION') ?: match (env('QUEUE_CONNECTION', 'database')) {
+        'redis' => 'redis-long-running',
+        'database' => 'database-long-running',
+        default => env('QUEUE_CONNECTION', 'database'),
+    },
+
+    /*
+    |--------------------------------------------------------------------------
     | Queue Connections
     |--------------------------------------------------------------------------
     |
@@ -40,6 +72,18 @@ return [
             'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'queue' => env('DB_QUEUE', 'default'),
             'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 90),
+            'after_commit' => false,
+        ],
+
+        // Same database queue, a `retry_after` that clears the badge-render job timeout.
+        // See the `long_running` note above for why this is a connection and not a setting
+        // on the job.
+        'database-long-running' => [
+            'driver' => 'database',
+            'connection' => env('DB_QUEUE_CONNECTION'),
+            'table' => env('DB_QUEUE_TABLE', 'jobs'),
+            'queue' => env('DB_QUEUE', 'default'),
+            'retry_after' => (int) env('LONG_RUNNING_QUEUE_RETRY_AFTER', 3660),
             'after_commit' => false,
         ],
 
@@ -68,6 +112,16 @@ return [
             'connection' => env('REDIS_QUEUE_CONNECTION', 'default'),
             'queue' => env('REDIS_QUEUE', 'default'),
             'retry_after' => (int) env('REDIS_QUEUE_RETRY_AFTER', 90),
+            'block_for' => null,
+            'after_commit' => false,
+        ],
+
+        // The connection `badge-render-supervisor` runs on under Horizon.
+        'redis-long-running' => [
+            'driver' => 'redis',
+            'connection' => env('REDIS_QUEUE_CONNECTION', 'default'),
+            'queue' => env('REDIS_QUEUE', 'default'),
+            'retry_after' => (int) env('LONG_RUNNING_QUEUE_RETRY_AFTER', 3660),
             'block_for' => null,
             'after_commit' => false,
         ],

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -63,6 +63,21 @@ never return a badge that some other run had already put into `Processing`. A ba
 only if a card is genuinely on its way for it - an outstanding job - not merely because it printed
 at some point in the past.
 
+**The render lane has its own queue connection, not just its own queue.** `badge-render` runs on
+`config('queue.long_running')` - `redis-long-running` under Horizon, `database-long-running` under a
+plain `queue:work` - because `retry_after` is a property of the connection. The shared connections
+keep it at 90 seconds so a job lost with its worker comes back quickly, and a run of a hundred cards
+is minutes of work: at 90 seconds the queue handed the still-running job to a second worker, which
+saw `attempts` past `tries = 1` and failed it with *"App\Jobs\Printing\PrepareBadgePrintBatchJob has
+been attempted too many times"*. That failure ran `failed()`, which cancelled the batch and returned
+the badges while the first worker was still rendering them - the same "sent to the printer with no
+card coming" shape the job was written to remove.
+
+The rule to keep: `LONG_RUNNING_QUEUE_RETRY_AFTER` (3660s) must stay above
+`PrepareBadgePrintBatchJob::$timeout` (3600s) and above `badge-render-supervisor`'s Horizon
+`timeout`. `BadgePrintPreparationTest` asserts it. Anything dispatched onto `badge-render` must set
+the same connection, or it lands in a queue no supervisor reads.
+
 This is the fix for a real outage. Rendering used to happen inline, in the request: a bulk print of
 unrendered badges spent seconds per card on an S3 read, a GD decode and an mpdf render, and blew
 PHP's 30 second limit partway through. What it left behind was worse than the error - every badge in

--- a/tests/Feature/Printing/BadgePrintPreparationTest.php
+++ b/tests/Feature/Printing/BadgePrintPreparationTest.php
@@ -104,6 +104,32 @@ it('renders on the badge-render queue rather than beside the panel', function ()
     );
 });
 
+/*
+ * The second half of that bug. Moving the work to a queue stopped the request dying, but
+ * the connection carrying it re-served the job after 90 seconds while it was still
+ * rendering: a second worker found attempts past tries = 1 and failed it with
+ * "App\Jobs\Printing\PrepareBadgePrintBatchJob has been attempted too many times", whose
+ * failed() hook cancelled the batch and returned the badges under the run still building
+ * them. A hundred cards is minutes of work, so retry_after has to clear the job's timeout.
+ */
+it('reserves a run for longer than it can take to prepare', function (string $connection) {
+    $timeout = (new ReflectionClass(PrepareBadgePrintBatchJob::class))
+        ->getDefaultProperties()['timeout'];
+
+    expect(config("queue.connections.{$connection}.retry_after"))->toBeGreaterThan($timeout);
+})->with(['database-long-running', 'redis-long-running']);
+
+it('prepares runs on the long-running connection, not the shared one', function () {
+    Queue::fake();
+
+    BadgePrintQueue::queue(preparableBadges(), Printer::factory()->badge()->create());
+
+    Queue::assertPushed(
+        PrepareBadgePrintBatchJob::class,
+        fn (PrepareBadgePrintBatchJob $job) => $job->connection === config('queue.long_running')
+    );
+});
+
 it('makes the run ready once the job has prepared it', function () {
     $badges = preparableBadges(2);
 


### PR DESCRIPTION
Large print runs failed with `App\Jobs\Printing\PrepareBadgePrintBatchJob has been attempted too many times`, cancelling the batch and dropping the badges back to Pending mid-render.

## Cause

That message is `MaxAttemptsExceededException`, not a timeout. `retry_after` is a property of the **queue connection**, not of the queue or the job, and the shared connections carry 90 seconds.

Preparing a run of 100 badges is 100 serial renders (an S3 read, a GD decode of a phone photo, an mpdf write each) inside `BadgePrintQueue::ensurePrintFiles()`. Past 90 seconds the queue made the still-running job visible again, a second worker reserved it, found `attempts` past `tries = 1` and failed it. That ran `failed()` -> `abandon()`, which cancelled the batch and returned the badges while the first worker was still rendering them.

`PrepareBadgePrintBatchJob::$timeout = 1800` could never help: the job was never reaching its timeout, it was being re-served underneath itself.

## Change

Give the render lane its own connection, with a `retry_after` above the job timeout.

- `config/queue.php`: new `long_running` key resolving to `redis-long-running` (Horizon) or `database-long-running` (plain `queue:work`), following `QUEUE_CONNECTION`. `sync` falls through to itself, so the test suite is unaffected. Both new connections use `LONG_RUNNING_QUEUE_RETRY_AFTER`, default 3660.
- `config/horizon.php`: `badge-render-supervisor` runs on `redis-long-running`; timeout 1800 -> 3600 in defaults, production and local.
- `PrepareBadgePrintBatchJob`: dispatches on `config('queue.long_running')`, timeout 3600.
- `GenerateBadgePrintFileJob`: same connection. It shares the `badge-render` queue, and one supervisor reads that queue on one connection, so a render left on the default connection would sit somewhere nothing reads.

The shared connections keep their 90 seconds, so a job lost with its worker on `default` or `batch-print` still comes back quickly.

A Redis queue key is derived from the queue name, not the connection name, so nothing already sitting in `badge-render` is orphaned by the move.

## Tests

- `retry_after` exceeds `PrepareBadgePrintBatchJob::$timeout` on both long-running connections.
- Preparation is pushed on `config('queue.long_running')`.
- `pest tests/Feature/Printing`: 122 passed. Full suite: 1217 passed, 10 skipped. Pint clean.

## Deploying

Set `LONG_RUNNING_QUEUE_RETRY_AFTER=3660` in the production environment, or the config default applies. Horizon needs a restart to pick up the supervisor's new connection.

## Not done here

If 100 badges still runs past 3600 seconds, the answer is fanning `ensurePrintFiles()` out as a `Bus::batch` with the commit in a chained job, rather than raising the numbers again. That breaks the current all-or-nothing commit and is a larger change, so it is left out.
