### PR TITLE
Fix print lease reaping and tray-full card loss

### DIFF
--- a/app/Enum/PrintJobStatusEnum.php
+++ b/app/Enum/PrintJobStatusEnum.php
@@ -15,7 +15,15 @@ enum PrintJobStatusEnum: string
     public function canTransitionTo(self $newStatus): bool
     {
         return match ($this) {
-            self::Pending => in_array($newStatus, [self::Queued, self::Cancelled], true),
+            // Printed and Failed are reachable from Pending because a reaped job is
+            // not necessarily a job nobody printed. The agent holds the card, and if
+            // its lease lapsed while the network was down it must still be able to
+            // say what happened when it comes back. Refusing that left a printed card
+            // sitting in the queue to be handed out and printed a second time, which
+            // is the exact failure this pipeline exists to prevent. Who may say it is
+            // decided at the endpoint: only the machine that owns the printer, and
+            // only while nobody else holds the job.
+            self::Pending => in_array($newStatus, [self::Queued, self::Printed, self::Failed, self::Cancelled], true),
             // Back to Pending covers an expired lease: the agent that claimed the
             // job died, so it returns to the queue rather than being lost.
             self::Queued => in_array($newStatus, [self::Printing, self::Pending, self::Failed, self::Cancelled], true),

--- a/app/Http/Controllers/PrintAgent/AgentJobController.php
+++ b/app/Http/Controllers/PrintAgent/AgentJobController.php
@@ -22,8 +22,18 @@ use Illuminate\Support\Facades\Storage;
  */
 class AgentJobController extends AgentController
 {
-    /** How long a claim is good for before the reaper takes it back. */
-    private const LEASE_SECONDS = 180;
+    /**
+     * How long a claim is good for before the reaper takes it back.
+     *
+     * Deliberately long. The lease exists to recover a card from an agent that
+     * has died, and nothing else; it is not a print timeout. A ZXP9 warming up
+     * can leave the Windows spooler holding the bytes for minutes with no
+     * heartbeat getting out, and at three minutes the reaper handed the card
+     * back to the queue while it was physically printing. One station prints
+     * one card at a time, so a fifteen minute wait to recover a genuinely dead
+     * agent costs nothing next to a duplicate card.
+     */
+    private const LEASE_SECONDS = 900;
 
     /**
      * Hand out the next job for the agent to print.
@@ -120,6 +130,22 @@ class AgentJobController extends AgentController
         $printJob = $this->jobForMachine($job);
         $this->touchAgent($request);
 
+        // Repeating a confirmation is not a second card. The agent's outbox
+        // resends anything it never got a reply to, so a delivery that crossed
+        // with a network drop arrives twice; treating the repeat as a refusal
+        // made the agent alert about a card that is recorded perfectly well.
+        if ($printJob->status === PrintJobStatusEnum::Printed) {
+            return response()->json([
+                'marked' => true,
+                'already_recorded' => true,
+                'status' => $printJob->status->value,
+            ]);
+        }
+
+        if ($conflict = $this->heldElsewhere($printJob)) {
+            return $conflict;
+        }
+
         $marked = $printJob->markPrinted(
             PrintCompletionSourceEnum::from($data['completion_source']),
             $data['firmware_job_id'] ?? null,
@@ -130,6 +156,29 @@ class AgentJobController extends AgentController
             'marked' => $marked,
             'status' => $printJob->fresh()->status->value,
         ]);
+    }
+
+    /**
+     * Refuse a result for a job some other machine is holding.
+     *
+     * The lease no longer decides whether a result is accepted - an agent that
+     * printed a card may report it late, after the reaper handed the job back -
+     * so this is what stops a late result overwriting work somebody else has
+     * since picked up. A job with no holder is fair game: that is the reaped
+     * card the reporting agent still has in its hand.
+     */
+    private function heldElsewhere(PrintJob $job): ?JsonResponse
+    {
+        $holder = $job->processing_machine_id;
+
+        if ($holder === null || $holder === $this->machine()->id) {
+            return null;
+        }
+
+        return response()->json([
+            'error' => 'Print job '.$job->id.' is held by another machine.',
+            'status' => $job->status->value,
+        ], 409);
     }
 
     /**
@@ -144,6 +193,21 @@ class AgentJobController extends AgentController
 
         $printJob = $this->jobForMachine($job);
         $this->touchAgent($request);
+
+        // A card that is already recorded as printed is not failed by a late
+        // message about it. Printed is terminal because the card physically
+        // exists, and the agent is told so rather than left thinking the
+        // failure was recorded.
+        if ($printJob->status === PrintJobStatusEnum::Printed) {
+            return response()->json([
+                'error' => 'Print job '.$printJob->id.' is already recorded as printed.',
+                'status' => $printJob->status->value,
+            ], 409);
+        }
+
+        if ($conflict = $this->heldElsewhere($printJob)) {
+            return $conflict;
+        }
 
         $printJob->markFailed($data['reason']);
 

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -147,6 +147,24 @@ pending -> queued -> printing -> printed
 agent or the Windows host dies, `printing:reap-leases` returns the job to the queue rather than
 leaving it stranded. Past three attempts it fails and pauses the batch.
 
+The lease is fifteen minutes (`AgentJobController::LEASE_SECONDS`), and it is deliberately not a
+print timeout. It was three minutes, which is less than a card takes: a ZXP9 warming up leaves the
+Windows spooler holding the bytes for minutes with no heartbeat getting out, so the reaper handed
+the card back to the queue while it was physically printing. One station prints one card at a time,
+so waiting longer to recover a genuinely dead agent costs nothing next to a duplicate card.
+
+**A late result is still the truth.** An agent that lost the network keeps the card, and reports it
+when it comes back - `Pending -> Printed` and `Pending -> Failed` are legal edges for exactly that
+reason. The endpoint accepts the result only from the machine that owns the printer and only while
+nobody else holds the job; a job claimed by somebody else in the meantime gets a 409. A repeated
+`printed` for a job already recorded is answered as recorded rather than refused, because the
+agent's outbox resends anything it never got a reply to.
+
+The agent will not print a card it has already put through the printer. Its local store keeps a row
+per job from before the file is sent until the server confirms the result, so a job handed out twice
+during an outage is recognised: already reported means send the result again, mid-print means ask
+the operator, and only a job that never reached the spooler is printed.
+
 **Claims are atomic.** `PrintBatch::claimNextJob()` locks the row, so two agents can never be handed
 the same card.
 
@@ -215,7 +233,16 @@ staff. Stops: `ribbon_out`, `film_out`, `cards_out`, `card_jam`, `cover_open`, `
 
 **`unknown` is a stop.** Zebra never published a MIB for the card printer line, so the fault
 vocabulary is learned from observation and will be incomplete. Anything unrecognised pauses the
-queue and is written to a journal for later mapping. See `print-agent/docs/snmp/README.md`.
+queue and is written to a journal for later mapping, and the log line names the strings it could not
+explain so nobody has to open a file on the print station to find out. See
+`print-agent/docs/snmp/README.md`.
+
+Two mapping rules learned the hard way. Every spelling of an exhausted consumable has to sit above
+the bare `ribbon` / `film` catch-all in `ALARM_CONDITIONS`, because the ZXP9 says `RIBBON EMPTY` and
+that matched only the catch-all - reported as a low ribbon, which is a warning the queue prints
+straight through. And a fault word in the state field is not an unknown state: the printer puts
+`COVER OPEN` and `SERVICE REQUIRED` there as well as in an alarm slot, and the journal was
+announcing both as something nobody understood.
 
 ## The agent
 
@@ -238,6 +265,26 @@ deliberately not a third.
 camera could not speak for the card, which is how the system ran before it existed; blank means a
 consumable is exhausted and every card after it would be blank too. The job is failed rather than
 reported printed, so it reprints once somebody has changed the consumable.
+
+**Except on a full tray, where the blank verdict means nothing.** The ink points are calibrated for
+a card lying where cards normally land; once the stack has risen they read the bin, the rim or a
+card standing half out of the chute, which is bright and colourless - indistinguishable from bare
+stock. So a blank verdict taken while the tray reads full reports the card, honestly unverified,
+and stops the run for the tray. Failing it instead put a badge that is sitting in the tray back in
+the queue for a second card.
+
+**A card takes as long as it takes.** The agent waits on the printer's own job table, and the
+firmware timeout bounds *silence* rather than print time: while a job row is in flight or the
+printer says it is printing or warming up, the deadline is pushed forward, up to a ceiling of twenty
+minutes. A cold start with a heating cycle runs well past the three minute timeout that used to
+apply, and giving up on it reported the card on the spooler's word alone while it was still in the
+machine, then asked the camera about a bin that was still empty.
+
+**Faults that can be seen to be fixed clear themselves.** Emptying the tray, clearing a jam or
+closing the cover resumes the run without anybody pressing Resume; the pause carries the check that
+would have to pass, and a jam cleared onto a still-full tray stays paused. Faults nothing can
+observe - a blank card, an unanswered reprint question - deliberately carry no check and still wait
+for a person.
 
 **What the camera deliberately does not do is identify which card it is.** Artwork hashing and OCR
 of the badge number were both built, tested on the real rig and removed. Every badge in a batch

--- a/print-agent/agent/ui/app.py
+++ b/print-agent/agent/ui/app.py
@@ -61,6 +61,27 @@ LABELS = {
 }
 
 
+def _unknown_line(findings) -> str:
+    """The log line for a reading the vocabulary could not explain.
+
+    Names the strings. The whole point of the journal is to turn an unknown
+    fault into a mapped one, and that only happens if whoever is standing at the
+    printer can read what the printer said without opening a file on it.
+    """
+    values = []
+
+    for finding in findings or []:
+        value = (finding.get("value") or "").strip()
+
+        if value and value not in values:
+            values.append(value)
+
+    if not values:
+        return "Unrecognised printer state written to the journal"
+
+    return "Unrecognised printer state written to the journal: %s" % ", ".join(values)
+
+
 def _positive_int(raw: str, fallback: int) -> int:
     """Parse a settings box, keeping the old value when it is not a number.
 
@@ -1364,8 +1385,12 @@ class AgentApp(tk.Tk):
         # existed and was never called: conditions were shown on this screen
         # and nowhere else.
         self.monitor.on_change.append(self._report_condition)
+        # Carries the strings themselves. "Something was unrecognised" sent the
+        # operator to a file on the print station to find out what; the values
+        # are two words long and belong in the line that mentions them.
         self.monitor.on_unknown.append(
-            lambda _: self.events.put(("unknown", None)))
+            lambda reading: self.events.put(
+                ("unknown", vocabulary.unknown_strings(reading))))
 
         thread = threading.Thread(target=self._monitor_loop, daemon=True)
         thread.start()
@@ -1479,7 +1504,7 @@ class AgentApp(tk.Tk):
                 elif kind == "reading":
                     self._apply_reading()
                 elif kind == "unknown":
-                    self._log("Unrecognised printer state written to the journal")
+                    self._log(_unknown_line(payload))
                     self._refresh_journal()
                 elif kind == "progress":
                     step, state, detail = payload

--- a/print-agent/agent/vocabulary.py
+++ b/print-agent/agent/vocabulary.py
@@ -70,8 +70,15 @@ def unknown_strings(reading: zebra.Reading) -> List[Dict[str, str]]:
     if sensor.lower() not in EMPTY_VALUES and not is_explained(sensor):
         findings.append({"field": "sensor_fault", "value": sensor})
 
+    # A fault word in the state field is not an unknown state. The ZXP9 puts
+    # COVER OPEN and SERVICE REQUIRED here as well as in an alarm slot, and the
+    # alarm vocabulary already knows exactly what both mean -- but this list
+    # holds only healthy states, so every recognised fault was also announced to
+    # the operator as something nobody understood. Ask the vocabulary first.
     state = (reading.printer_state or "").strip()
-    if state.lower() not in EMPTY_VALUES and state.lower() not in KNOWN_PRINTER_STATES:
+    if (state.lower() not in EMPTY_VALUES
+            and state.lower() not in KNOWN_PRINTER_STATES
+            and not is_explained(state)):
         findings.append({"field": "printer_state", "value": state})
 
     for row in reading.jobs:

--- a/print-agent/agent/worker.py
+++ b/print-agent/agent/worker.py
@@ -67,7 +67,7 @@ from .api import (
     ApiError,
     NetworkError,
 )
-from . import autostart
+from . import autostart, zebra
 from .config import ROLE_CARD, ROLE_RECEIPT
 from .store import OUTBOX_FAILED, OUTBOX_PRINTED, OUTBOX_VERIFY
 
@@ -333,6 +333,10 @@ class _BaseWorker:
         # True only when paused because there is nothing to print, as opposed
         # to paused because something needs a human. See pause().
         self.waiting_for_work = False
+
+        # What would have to become true for this pause to clear itself. Set by
+        # whichever step knew why we stopped; see pause(resume_when=...).
+        self._resume_when: Optional[Callable[[], bool]] = None
         self._thread: Optional[threading.Thread] = None
 
         self.state = IDLE
@@ -379,18 +383,28 @@ class _BaseWorker:
     def _unblock(self) -> None:
         """Release anything the loop might be sitting on when stop() arrives."""
 
-    def pause(self, reason: str = "", waiting_for_work: bool = False) -> None:
+    def pause(self, reason: str = "", waiting_for_work: bool = False,
+              resume_when: Optional[Callable[[], bool]] = None) -> None:
         """Stop between cards.
 
         ``waiting_for_work`` distinguishes "there is nothing to print" from
         "something is wrong". Only the first may be cleared automatically:
         switching on unattended mode should pick a parked worker back up, but
         it must never shrug off a jam nobody has looked at.
+
+        ``resume_when`` is how a fault clears itself. Some faults are fixed by
+        doing the obvious physical thing -- emptying the tray, clearing a jam,
+        closing the cover -- and the machine can see that it happened. Those
+        pass a check here and the loop carries on by itself once it passes,
+        rather than leaving a station idle because nobody walked back to it and
+        pressed Resume. Faults nothing can observe (a blank card, an unanswered
+        reprint question) deliberately pass nothing and still wait for a human.
         """
         self._paused.set()
         self.state = PAUSED
         self.status_detail = reason
         self.waiting_for_work = bool(waiting_for_work)
+        self._resume_when = resume_when
 
         if reason:
             self._log(reason)
@@ -400,6 +414,32 @@ class _BaseWorker:
         self.state = RUNNING if self.is_alive() else IDLE
         self.status_detail = ""
         self.waiting_for_work = False
+        self._resume_when = None
+
+    def _resume_if_cleared(self) -> bool:
+        """Take a paused worker off pause once its fault has gone away.
+
+        Never guesses: a check that raises, or that has not been given, leaves
+        the worker paused. Being stuck is recoverable by a person; printing
+        onto a printer that is still broken is not.
+        """
+        check = self._resume_when
+
+        if check is None:
+            return False
+
+        try:
+            cleared = bool(check())
+        except Exception:  # noqa: BLE001 - an unreadable printer is not a fixed one
+            return False
+
+        if not cleared:
+            return False
+
+        self._log("The printer is ready again. Carrying on.")
+        self.resume()
+
+        return True
 
     def is_alive(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
@@ -449,6 +489,34 @@ class _BaseWorker:
             return self.sender(job, path, self.binding)
         except Exception as error:  # noqa: BLE001 - a broken sender is a failed job, not a crash
             return SpoolResult(False, str(error))
+
+    def _spool_holding_lease(self, job: Dict[str, Any], path: str, job_id: int) -> Any:
+        """Hand the file to the spooler while keeping the lease alive.
+
+        The sender blocks until Windows has taken the job, and a ZXP9 that is
+        warming up leaves it blocked for minutes. Nothing renewed the lease in
+        that window: the card was physically printing, the server heard nothing,
+        and the reaper handed the job back to the queue to be printed again.
+
+        Real seconds, not the injected clock. This waits on the spooler, not on
+        the print timeouts the clock exists to drive.
+        """
+        done = threading.Event()
+        interval = self.heartbeat_seconds if self.heartbeat_seconds > 0 else 1.0
+
+        def keep_lease() -> None:
+            while not done.wait(interval):
+                self._call(self.api.heartbeat, job_id)
+
+        keeper = threading.Thread(
+            target=keep_lease, name="lease-%s" % job_id, daemon=True
+        )
+        keeper.start()
+
+        try:
+            return self._spool(job, path)
+        finally:
+            done.set()
 
     def _report(
         self,
@@ -635,13 +703,15 @@ class _BaseWorker:
             return True
 
         if entry.kind == OUTBOX_PRINTED:
-            self.api.mark_printed(
+            # Same rule as the live call: a reply that says the job was not
+            # recorded is not a delivery, and marking the row sent would drop
+            # the only evidence that this card exists.
+            return _recorded(self.api.mark_printed(
                 job_id,
                 payload.get("completion_source"),
                 payload.get("firmware_job_id"),
                 payload.get("firmware_job_uuid"),
-            )
-            return True
+            ))
 
         if entry.kind == OUTBOX_VERIFY:
             self.api.verify(job_id, payload.get("source", VERIFY_CAMERA))
@@ -656,8 +726,24 @@ class _BaseWorker:
     def _deliver(self, kind: str, payload: Dict[str, Any], call: Callable[[], Any]) -> bool:
         """Make one confirmation call, falling back to the outbox."""
         try:
-            call()
-            return True
+            if _recorded(call()):
+                return True
+
+            # A 200 that says "not recorded". The call went through and the
+            # server declined to move the job, which used to count as delivered:
+            # the agent forgot the card, the job stayed queued server side, and
+            # the next claim printed it again. Keep it and say so.
+            self._call(self.store.enqueue_outbox, kind, payload)
+            self._log("Server did not record %s for job %s; kept locally."
+                      % (kind, payload.get("job_id")))
+            self._alert(
+                "report:%s" % payload.get("job_id"),
+                "A print result was not recorded",
+                "%s for job %s was refused by the server. The card exists; the "
+                "job may still be queued." % (kind, payload.get("job_id")),
+            )
+
+            return False
         except NetworkError as error:
             self._call(self.store.enqueue_outbox, kind, payload)
             self._log("Server unreachable; %s for job %s queued locally (%s)."
@@ -672,6 +758,22 @@ class _BaseWorker:
                 return False
 
             self._log("Server refused %s for job %s: %s" % (kind, payload.get("job_id"), error.message))
+
+            if error.status == 409:
+                # The job moved on without us: another machine holds it, or it
+                # is already recorded some other way. A card exists here that
+                # the server is not crediting to this job, and that is the shape
+                # a duplicate print comes in. Keep the record and say so loudly.
+                self._call(self.store.enqueue_outbox, kind, payload)
+                self._alert(
+                    "report:%s" % payload.get("job_id"),
+                    "A printed card is not recorded against its job",
+                    "%s for job %s was refused: %s. Check the card before it is "
+                    "printed again." % (kind, payload.get("job_id"), error.message),
+                )
+
+                return False
+
             # The card printed; only the bookkeeping failed, and the outbox
             # keeps retrying. Nobody needs waking for it.
             self._alert(
@@ -827,6 +929,7 @@ class PrintWorker(_BaseWorker):
         low_card_threshold: int = 10,
         heartbeat_seconds: float = 45.0,
         firmware_timeout: float = 180.0,
+        max_print_seconds: float = 1200.0,
         poll_seconds: float = 1.0,
         idle_seconds: float = 3.0,
         stop_confirmations: int = 2,
@@ -863,7 +966,16 @@ class PrintWorker(_BaseWorker):
         self.on_decision = on_decision
         self.on_batch_change = on_batch_change
 
+        # How long the printer may say nothing at all about a card before we
+        # settle for the spooler's word. Silence, not print time: the deadline
+        # is pushed forward while the printer is visibly working.
         self.firmware_timeout = firmware_timeout
+
+        # The ceiling on one card, however busy the printer claims to be. Twenty
+        # minutes covers a cold start with a heating cycle several times over,
+        # and still ends a run rather than leaving it hanging on a machine stuck
+        # in "printing".
+        self.max_print_seconds = max_print_seconds
 
         # How many consecutive polls must agree that the printer has stopped
         # before we fail the card in flight. One flaky SNMP timeout is not a jam,
@@ -879,9 +991,14 @@ class PrintWorker(_BaseWorker):
 
         self.pending_decision: Optional[ReprintDecision] = None
 
-        # Latched by the tray-full checkpoint. Cleared only by resume(), because
-        # clearing it any other way means printing into a tray nobody emptied.
+        # Latched by the tray-full checkpoint. Cleared by resume(), or by the
+        # camera seeing an empty tray again -- never by anything that has not
+        # actually looked, because that means printing into a full tray.
         self.tray_full = False
+
+        # What the step that stopped us would accept as "fixed", handed to
+        # pause() by the run loop. None means only a person can clear it.
+        self._recheck: Optional[Callable[[], bool]] = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -895,7 +1012,8 @@ class PrintWorker(_BaseWorker):
             # was made, and the card stays failed rather than guessed at.
             decision._answered.set()
 
-    def pause(self, reason: str = "", waiting_for_work: bool = False) -> None:
+    def pause(self, reason: str = "", waiting_for_work: bool = False,
+              resume_when: Optional[Callable[[], bool]] = None) -> None:
         """Stop between cards, and tell the server the batch is paused.
 
         Reporting matters as much as stopping. The server used to be told
@@ -905,7 +1023,7 @@ class PrintWorker(_BaseWorker):
 
         Best-effort: a network problem must never stop the worker pausing.
         """
-        super().pause(reason, waiting_for_work=waiting_for_work)
+        super().pause(reason, waiting_for_work=waiting_for_work, resume_when=resume_when)
 
         if self.batch_id is not None:
             self._call(getattr(self.api, "pause_batch", None), self.batch_id,
@@ -967,7 +1085,12 @@ class PrintWorker(_BaseWorker):
 
         while not self._stop.is_set():
             if self._paused.is_set():
-                self._sleep(self.idle_seconds)
+                # A fault that can be seen to be fixed clears itself: the tray
+                # gets emptied, the jam gets cleared, and the run carries on
+                # without somebody walking back to press Resume.
+                if not self._resume_if_cleared():
+                    self._sleep(self.idle_seconds)
+
                 continue
 
             outcome = self.print_next()
@@ -999,8 +1122,10 @@ class PrintWorker(_BaseWorker):
                 # Pausing to ask a second time would be pointless.
                 continue
 
-            # Everything else stopped the queue and needs somebody to look at it.
-            self.pause(outcome.detail)
+            # Everything else stopped the queue and needs somebody to look at
+            # it. The step that stopped says whether "looked at" is something
+            # the machine can notice for itself; see pause(resume_when=...).
+            self.pause(outcome.detail, resume_when=self._recheck)
 
         self.state = HALTED if self._stop.is_set() else self.state
 
@@ -1012,11 +1137,16 @@ class PrintWorker(_BaseWorker):
         self._reset_pipeline()
         self.current_job = None
 
+        # Nothing has stopped us yet, so no pause of ours is recoverable yet.
+        self._recheck = None
+
         if self.tray_full or self._tray_is_full():
             self.tray_full = True
             detail = "Output tray is full. Empty it before printing more cards."
             self._progress(STEP_CLAIM, FAILED, "tray full")
             self._alert("tray:%s" % self.printer_name, "Output tray full", detail)
+            self._recheck = self._tray_cleared
+
             return Outcome(TRAY_FULL, detail)
 
         blocked = self._gate()
@@ -1038,6 +1168,11 @@ class PrintWorker(_BaseWorker):
                 "%s stopped" % (self.printer_name or "Printer"),
                 blocked,
             )
+
+            # A jam, an open cover, an empty hopper: the printer itself tells us
+            # when it has been dealt with, so the run picks itself back up.
+            self._recheck = self._printer_ready
+
             return Outcome(BLOCKED, blocked)
 
         if self.batch_id is None:
@@ -1146,6 +1281,12 @@ class PrintWorker(_BaseWorker):
         if attempt > 1:
             self._reset_pipeline()
 
+        if attempt == 1:
+            already = self._already_handled(job)
+
+            if already is not None:
+                return already
+
         self._progress(STEP_CLAIM, DONE, "card %s" % self._card_number(job))
 
         # Cached before anything is printed. From here on the card is committed
@@ -1172,7 +1313,7 @@ class PrintWorker(_BaseWorker):
         # a picture taken afterwards would already contain it.
         self._arm_camera()
 
-        spooled = _as_spool_result(self._spool(job, path))
+        spooled = _as_spool_result(self._spool_holding_lease(job, path, job_id))
 
         if not spooled.ok:
             self._progress(STEP_SPOOL, FAILED, spooled.detail or "the spooler refused the job")
@@ -1200,6 +1341,29 @@ class PrintWorker(_BaseWorker):
 
         verification = self._verify(job)
 
+        if verification.blank and self._tray_is_full():
+            # A full tray moves the card. The ink points are calibrated for a
+            # card lying where cards normally land, and once the stack has risen
+            # they read the bin, the rim or a card standing half out of the
+            # chute -- bright and colourless, which is exactly what bare card
+            # stock looks like. Failing the job on that reading loses a card
+            # that is sitting in the tray: the badge goes back in the queue and
+            # a second one gets printed for it.
+            #
+            # So the card is reported, honestly unverified, and the run stops
+            # for the tray rather than for a consumable that has not run out.
+            self.tray_full = True
+            detail = ("Card %s printed, but the tray is full and the blank check "
+                      "cannot be trusted with the stack this high."
+                      % self._card_number(job))
+            self._log(detail)
+            self._alert("tray:%s" % self.printer_name, "Output tray full", detail)
+            self._report(job, completion,
+                         Verification(True, False, "tray full; blank check not trusted"))
+            self._recheck = self._tray_cleared
+
+            return Outcome(TRAY_FULL, detail, job_id)
+
         if verification.blank:
             # A card came out, but with nothing on it: the ribbon or the
             # transfer film has run out. Deliberately not reported as printed.
@@ -1211,6 +1375,79 @@ class PrintWorker(_BaseWorker):
         self._report(job, completion, verification)
 
         return Outcome(PRINTED, completion.detail, job_id)
+
+    def _already_handled(self, job: Dict[str, Any]) -> Optional[Outcome]:
+        """Refuse to print a card this agent has already put through the printer.
+
+        The server can hand the same job out twice. A lease that lapsed during a
+        network outage is returned to the queue by the reaper, and the next claim
+        is allowed to pick it up -- so without this, a printer that went quiet for
+        a few minutes comes back and prints the same badge again, and keeps doing
+        it for as long as the outage lasts.
+
+        The local store is the record that survives all of it: a job row is written
+        before the file is sent and is not deleted until the server has confirmed
+        the result. What that row says decides what happens here.
+
+        Returns None when there is nothing on file and the card should be printed.
+        """
+        try:
+            record = self.store.job(int(job["id"]))
+        except Exception:  # noqa: BLE001 - an unreadable store is no information
+            return None
+
+        status = (record or {}).get("status")
+
+        if status in (None, JOB_CLAIMED):
+            # Claimed and no further: nothing was ever sent to the printer.
+            return None
+
+        job_id = int(job["id"])
+        card = self._card_number(job)
+
+        if status in (JOB_REPORTED, JOB_DONE):
+            # The card exists and we already know how it went; only the
+            # bookkeeping is outstanding. Deliver that instead of a second card.
+            detail = "Card %s was already printed here; sending the result again." % card
+            self._log(detail)
+            self._progress(STEP_CLAIM, SKIPPED, "already printed")
+            self.flush_outbox()
+
+            return Outcome(PRINTED, detail, job_id)
+
+        # JOB_PRINTING: the file went to the spooler and we never recorded what
+        # came of it. The card may well be in the stack. Nobody here can tell,
+        # and guessing either way is how a badge goes missing or gets printed
+        # twice, so it goes to the person who can look at the stack.
+        reason = ("Card %s was already sent to the printer before the connection "
+                  "dropped. Check the stack before it is printed again." % card)
+        self._log(reason)
+
+        answer = self._ask_operator(job, reason)
+
+        if answer is None:
+            self.status_detail = reason
+            return Outcome(WAITING, reason, job_id)
+
+        if answer == CHOICE_PRINTED:
+            self._report(
+                job,
+                Completion(COMPLETION_OPERATOR, "operator found the card in the stack"),
+                Verification(True, True, "operator"),
+                verification_source=VERIFY_OPERATOR,
+            )
+
+            return Outcome(PRINTED, "operator confirmed the card is in the stack", job_id)
+
+        if answer == CHOICE_SKIP:
+            detail = "Operator skipped card %s (%s)" % (card, reason)
+            self._log(detail)
+            self._fail(job, detail)
+
+            return Outcome(JOB_SKIPPED, detail, job_id)
+
+        # CHOICE_REPRINT: the operator looked and there is no card. Print it.
+        return None
 
     def _handle_blank(self, job: Dict[str, Any]) -> Outcome:
         """A card came out of the printer unprinted.
@@ -1333,13 +1570,26 @@ class PrintWorker(_BaseWorker):
 
         The lease is renewed throughout: a retransfer card takes well over a
         minute and an unrenewed lease is reaped out from under us mid-print.
+
+        ``firmware_timeout`` bounds *silence*, not the card. A ZXP9 coming up to
+        temperature takes several minutes before it prints anything, and a fixed
+        deadline gave up on a card that was visibly still being worked on: the
+        job was reported ``spooler_only`` while it was in the machine, the camera
+        was then asked about a bin with nothing in it yet, and the run moved on
+        to the next card. So the deadline is pushed forward for as long as the
+        printer is demonstrably busy -- a job row in flight, or a printing or
+        warming-up state -- and ``max_print_seconds`` is the ceiling that stops a
+        printer stuck in "printing" from holding the queue forever.
         """
         self._progress(STEP_FIRMWARE, ACTIVE, "waiting for the printer to confirm")
 
-        deadline = self._clock() + self.firmware_timeout
+        started = self._clock()
+        deadline = started + self.firmware_timeout
+        ceiling = started + max(self.firmware_timeout, self.max_print_seconds)
         last_beat = self._clock()
         matched = None
         stop_streak = 0
+        said_slow = False
 
         while True:
             reading = self._read_printer()
@@ -1384,6 +1634,16 @@ class PrintWorker(_BaseWorker):
 
             now = self._clock()
 
+            # Still working on it. The clock for "the printer never said
+            # anything" restarts every time it shows that it is doing something.
+            if self._card_in_progress(row):
+                deadline = min(now + self.firmware_timeout, ceiling)
+
+                if not said_slow and now - started >= self.firmware_timeout:
+                    said_slow = True
+                    self._progress(STEP_FIRMWARE, ACTIVE,
+                                   "the printer is still working on this card")
+
             if now - last_beat >= self.heartbeat_seconds:
                 self._call(self.api.heartbeat, job_id)
                 last_beat = now
@@ -1400,6 +1660,20 @@ class PrintWorker(_BaseWorker):
                 )
 
             self._sleep(self.poll_seconds)
+
+    def _card_in_progress(self, row: Optional[Any]) -> bool:
+        """Whether the printer is visibly still working on this card.
+
+        Two independent signs, either of which is enough. The firmware's own job
+        row is the better one: a row that is neither done nor failed is a card in
+        the machine. The printer's state word covers the window before the row
+        appears at all, which on a cold ZXP9 is the several minutes it spends
+        heating the transfer roller.
+        """
+        if row is not None and row.is_in_flight():
+            return True
+
+        return self._condition() in (zebra.PRINTING, zebra.INITIALIZING)
 
     def _verify(self, job: Dict[str, Any]) -> Verification:
         """Ask the camera whether the right card came out.
@@ -1524,6 +1798,29 @@ class PrintWorker(_BaseWorker):
             return None
 
         return self._blocking_reason() or "The printer is not ready."
+
+    def _printer_ready(self) -> bool:
+        """Whether the thing that stopped the run has been dealt with.
+
+        Asked while paused, so it must be the whole question and not just the
+        printer's own opinion: a cleared jam with a full tray underneath it is
+        still a station that must not print.
+        """
+        return self._gate() is None and not self._tray_is_full()
+
+    def _tray_cleared(self) -> bool:
+        """Whether the output tray has been emptied.
+
+        Drops the latch as well as answering, because the latch is what
+        print_next() reads on its way in and a stale one would stop the very
+        card this check just allowed.
+        """
+        if self._tray_is_full():
+            return False
+
+        self.tray_full = False
+
+        return self._gate() is None
 
     def _wait_until_healthy(self) -> bool:
         """Block until the printer is printable again, or we are told to stop."""
@@ -1921,6 +2218,21 @@ class ReceiptWorker(_BaseWorker):
 
 
 # --- Helpers ------------------------------------------------------------------
+
+
+def _recorded(response: Any) -> bool:
+    """Whether the server actually wrote down what we told it.
+
+    A 200 is not the same answer as "recorded". ``printed`` replies with
+    ``marked: false`` when it declined to move the job, and treating that as a
+    delivery is how a card that exists goes back into the queue to be printed
+    again. Anything that is not an explicit refusal counts as recorded, so a
+    stub client or an endpoint that returns nothing behaves as it always did.
+    """
+    if isinstance(response, dict) and response.get("marked") is False:
+        return False
+
+    return True
 
 
 def _row_key(row: Any) -> tuple:

--- a/print-agent/agent/zebra.py
+++ b/print-agent/agent/zebra.py
@@ -113,6 +113,12 @@ BIT_CONDITIONS = [
 # Substrings seen in the Zebra alarm slots and sensor fault field. The healthy
 # value is the literal string "none"; the fault vocabulary is filled in from
 # real faults captured with tools/snmp_probe.py.
+#
+# Order is the whole design here: the first needle that matches wins, so every
+# exhausted-consumable spelling has to come before the bare "ribbon" / "film"
+# catch-all underneath it. The ZXP9 says RIBBON EMPTY when it runs out, which
+# matched only the catch-all and was reported as a low ribbon -- a warning the
+# queue prints straight through, on a printer that cannot print.
 ALARM_CONDITIONS = [
     ("jam", CARD_JAM),
     ("cover", COVER_OPEN),
@@ -120,16 +126,43 @@ ALARM_CONDITIONS = [
     ("ribbon_out", RIBBON_OUT),
     ("ribbon out", RIBBON_OUT),
     ("out_of_ribbon", RIBBON_OUT),
+    ("out of ribbon", RIBBON_OUT),
+    ("ribbon_empty", RIBBON_OUT),
+    ("ribbon empty", RIBBON_OUT),
+    ("empty_ribbon", RIBBON_OUT),
+    ("empty ribbon", RIBBON_OUT),
+    ("no_ribbon", RIBBON_OUT),
+    ("no ribbon", RIBBON_OUT),
     ("ribbon", RIBBON_LOW),
     ("film_out", FILM_OUT),
     ("out_of_film", FILM_OUT),
+    ("out of film", FILM_OUT),
+    ("film_empty", FILM_OUT),
+    ("film empty", FILM_OUT),
+    ("empty_film", FILM_OUT),
+    ("empty film", FILM_OUT),
+    ("no_film", FILM_OUT),
+    ("no film", FILM_OUT),
     ("film", FILM_LOW),
     ("empty_feeder", CARDS_OUT),
     ("out_of_cards", CARDS_OUT),
+    ("out of cards", CARDS_OUT),
     ("no_cards", CARDS_OUT),
+    ("no cards", CARDS_OUT),
+    ("cards_empty", CARDS_OUT),
+    ("cards empty", CARDS_OUT),
+    ("feeder_empty", CARDS_OUT),
+    ("feeder empty", CARDS_OUT),
     ("hopper", CARDS_OUT),
     ("reject", REJECT_BIN_FULL),
+    ("output_full", REJECT_BIN_FULL),
+    ("output full", REJECT_BIN_FULL),
     ("service", SERVICE_REQUIRED),
+    ("mechanical_error", SERVICE_REQUIRED),
+    ("mechanical error", SERVICE_REQUIRED),
+    ("head_open", COVER_OPEN),
+    ("head open", COVER_OPEN),
+    ("lid", COVER_OPEN),
 ]
 
 # Job states from 10642.8.5.1.4. done_ok is the only one that means a finished

--- a/print-agent/tests/test_vocabulary.py
+++ b/print-agent/tests/test_vocabulary.py
@@ -40,6 +40,14 @@ class UnknownStringsTest(unittest.TestCase):
         result = vocabulary.unknown_strings(reading(printer_state="calibrating"))
         self.assertEqual(result[0]["field"], "printer_state")
 
+    def test_does_not_flag_a_fault_word_in_the_state_field(self):
+        # The ZXP9 puts COVER OPEN and SERVICE REQUIRED in the state field as
+        # well as in an alarm slot. Both are mapped, both stop the printer, and
+        # both were being announced to the operator as states nobody understood.
+        for state in ("COVER OPEN", "SERVICE REQUIRED", "RIBBON EMPTY"):
+            self.assertEqual(vocabulary.unknown_strings(reading(printer_state=state)), [],
+                             state)
+
     def test_flags_an_unknown_job_state(self):
         rows = [zebra.JobRow(index=1, state="rejected_bad_card")]
         result = vocabulary.unknown_strings(reading(jobs=rows))

--- a/print-agent/tests/test_worker.py
+++ b/print-agent/tests/test_worker.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -1224,6 +1225,329 @@ class WaitingForWorkTest(WorkerTestCase):
         printer.pause("something went wrong")
 
         self.assertFalse(printer.waiting_for_work)
+
+
+class HeatingCycleTest(WorkerTestCase):
+    """A card that takes minutes, because the printer heats up first.
+
+    A cold ZXP9 brings the transfer roller up to temperature before it prints
+    anything, and the whole card can take the better part of ten minutes. The
+    fixed firmware timeout gave up at three: the job was reported on the
+    spooler's word alone while the card was still in the machine, the camera was
+    then asked about a bin with nothing in it yet, and the run moved on.
+    """
+
+    def heats_for(self, seconds, job_id="9095"):
+        """A printer that warms up for `seconds`, then produces the card."""
+        started = self.clock.now
+        read = self.printer.read
+
+        def heat():
+            if self.clock.now - started >= seconds and not self.printer.jobs:
+                self.printer.finish(job_id=job_id, uuid="uuid-%s" % job_id)
+                self.printer.reading_kwargs["printer_state"] = "idle"
+
+            return read()
+
+        self.printer.read = heat
+
+    def sender_that_heats(self, job_payload, path, binding):
+        self.sent.append((job_payload["id"], path))
+        # What the firmware actually reports while the roller comes up.
+        self.printer.reading_kwargs["printer_state"] = "printing_heating"
+
+        return worker.SpoolResult(True, "spool id 42")
+
+    def test_a_six_minute_card_is_still_confirmed_by_the_firmware(self):
+        self.api.queue.append(job(95))
+        self.heats_for(360)
+
+        outcome = self.build(sender=self.sender_that_heats,
+                             firmware_timeout=180.0,
+                             poll_seconds=5.0).print_next()
+
+        self.assertEqual(outcome.kind, worker.PRINTED)
+        self.assertEqual(self.api.printed[0]["completion_source"], api.COMPLETION_FIRMWARE)
+        self.assertGreaterEqual(self.clock.slept, 360.0,
+                                "the card must not be given up on while it is printing")
+
+    def test_the_lease_is_renewed_across_the_whole_wait(self):
+        self.api.queue.append(job(96))
+        self.heats_for(360, job_id="9096")
+
+        self.build(sender=self.sender_that_heats,
+                   firmware_timeout=180.0,
+                   heartbeat_seconds=45.0,
+                   poll_seconds=5.0).print_next()
+
+        # Six minutes at a beat every forty-five seconds. Anything much less
+        # means a window where the reaper could take the card back.
+        self.assertGreaterEqual(len(self.api.heartbeats), 6)
+        self.assertEqual(set(self.api.heartbeats), {96})
+
+    def test_a_printer_stuck_in_printing_still_ends(self):
+        # The extension is bounded. A machine that claims to be printing for
+        # ever must not hold the queue for ever with it.
+        self.api.queue.append(job(97))
+        self.confirm_in_firmware = False
+
+        outcome = self.build(sender=self.sender_that_heats,
+                             firmware_timeout=180.0,
+                             max_print_seconds=900.0,
+                             poll_seconds=15.0).print_next()
+
+        self.assertEqual(outcome.kind, worker.PRINTED)
+        self.assertEqual(self.api.printed[0]["completion_source"], api.COMPLETION_SPOOLER_ONLY)
+        self.assertGreaterEqual(self.clock.slept, 900.0)
+        self.assertLess(self.clock.slept, 1200.0)
+
+    def test_a_quiet_printer_still_gives_up_at_the_silence_timeout(self):
+        # Nothing in the job table and nothing in the state word: the card is
+        # not visibly in progress, so the old behaviour is exactly right.
+        self.api.queue.append(job(98))
+        self.confirm_in_firmware = False
+
+        self.build(firmware_timeout=60.0, max_print_seconds=900.0, poll_seconds=5.0).print_next()
+
+        self.assertEqual(self.api.printed[0]["completion_source"], api.COMPLETION_SPOOLER_ONLY)
+        self.assertLess(self.clock.slept, 120.0)
+
+
+class AlreadyHandledTest(WorkerTestCase):
+    """A card this agent has already put through the printer.
+
+    The server can hand the same job out twice: a lease that lapsed while the
+    network was down is returned to the queue by the reaper, and the next claim
+    picks it up. Without a check against what we did locally, an outage turns
+    into the same badge printed over and over for as long as it lasts.
+    """
+
+    def test_a_reported_card_is_not_printed_again(self):
+        payload = job(70)
+        self.store.save_job(payload, "ZXP9-Left", 77, worker.JOB_REPORTED)
+        self.api.queue.append(payload)
+
+        outcome = self.build().print_next()
+
+        self.assertEqual(outcome.kind, worker.PRINTED)
+        self.assertEqual(self.sent, [], "nothing may be sent for a card we already printed")
+
+    def test_a_card_that_was_mid_print_goes_to_the_operator(self):
+        # Sent to the spooler, and we never learned what came of it. Neither
+        # reprinting nor recording it is safe without somebody looking.
+        payload = job(71, custom_id="24-0071")
+        self.store.save_job(payload, "ZXP9-Left", 77, worker.JOB_PRINTING)
+        self.api.queue.append(payload)
+
+        outcome = self.build().print_next()
+
+        self.assertEqual(outcome.kind, worker.WAITING)
+        self.assertEqual(self.sent, [])
+        self.assertTrue(self.decisions, "the operator has to be asked")
+        self.assertIn("24-0071", self.decisions[0].reason)
+
+    def test_the_operator_can_confirm_the_card_is_in_the_stack(self):
+        payload = job(72)
+        self.store.save_job(payload, "ZXP9-Left", 77, worker.JOB_PRINTING)
+        self.api.queue.append(payload)
+
+        printer = self.auto_answer(self.build(), worker.CHOICE_PRINTED)
+        outcome = printer.print_next()
+
+        self.assertEqual(outcome.kind, worker.PRINTED)
+        self.assertEqual(self.sent, [])
+        self.assertEqual([entry["completion_source"] for entry in self.api.printed],
+                         [worker.COMPLETION_OPERATOR])
+
+    def test_the_operator_can_say_no_card_came_out(self):
+        payload = job(73)
+        self.store.save_job(payload, "ZXP9-Left", 77, worker.JOB_PRINTING)
+        self.api.queue.append(payload)
+
+        printer = self.auto_answer(self.build(), worker.CHOICE_REPRINT)
+        outcome = printer.print_next()
+
+        self.assertEqual(outcome.kind, worker.PRINTED)
+        self.assertEqual([sent_id for sent_id, _path in self.sent], [73],
+                         "a card the operator could not find must still be printed")
+
+    def test_a_claimed_but_unsent_card_prints_normally(self):
+        # Claimed and no further: the file never reached the spooler, so there
+        # is no card and nothing to ask about.
+        payload = job(74)
+        self.store.save_job(payload, "ZXP9-Left", 77, worker.JOB_CLAIMED)
+        self.api.queue.append(payload)
+
+        outcome = self.build().print_next()
+
+        self.assertEqual(outcome.kind, worker.PRINTED)
+        self.assertEqual([sent_id for sent_id, _path in self.sent], [74])
+
+
+class SpoolLeaseTest(WorkerTestCase):
+    """The lease has to survive the spooler blocking.
+
+    A ZXP9 warming up leaves the sender blocked for minutes with the card
+    already committed. Nothing renewed the lease in that window, so the reaper
+    handed the job back to the queue while it was physically printing.
+    """
+
+    def test_a_slow_spool_keeps_the_lease_alive(self):
+        self.api.queue.append(job(80))
+
+        def slow_sender(job_payload, path, binding):
+            time.sleep(0.25)
+            return self.sender(job_payload, path, binding)
+
+        self.build(sender=slow_sender, heartbeat_seconds=0.05).print_next()
+
+        self.assertIn(80, self.api.heartbeats)
+
+
+class TrayFullBlankTest(WorkerTestCase):
+    """A blank verdict read off a full tray is not evidence of a blank card.
+
+    The ink points are calibrated for a card lying where cards normally land.
+    Once the stack has risen they read the bin, the rim, or a card standing half
+    out of the chute -- bright and colourless, which is what bare stock looks
+    like. Failing the job on that loses a card that is sitting in the tray.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.camera = FakeCamera(blank=True)
+
+    def fills_the_tray(self, job_payload, path, binding):
+        """A sender whose card is the one that fills the tray up."""
+        self.camera._tray_full = True
+
+        return self.sender(job_payload, path, binding)
+
+    def test_the_card_is_reported_rather_than_failed(self):
+        self.api.queue.append(job(85))
+
+        outcome = self.build(sender=self.fills_the_tray).print_next()
+
+        self.assertEqual(outcome.kind, worker.TRAY_FULL)
+        self.assertEqual([entry["job_id"] for entry in self.api.printed], [85])
+        self.assertEqual(self.api.failed, [],
+                         "a card in a full tray must not be failed as blank")
+
+    def test_it_is_reported_unverified(self):
+        # The camera could not speak for this card, which is honest. Claiming a
+        # verification off a reading we have just called untrustworthy is not.
+        self.api.queue.append(job(86))
+
+        self.build(sender=self.fills_the_tray).print_next()
+
+        self.assertEqual(self.api.verified, [])
+
+    def test_the_run_stops_for_the_tray(self):
+        self.api.queue.extend([job(87), job(88)])
+
+        printer = self.build(sender=self.fills_the_tray)
+        printer.print_next()
+
+        self.assertTrue(printer.tray_full)
+        self.assertEqual(printer.print_next().kind, worker.TRAY_FULL)
+        self.assertEqual(len(self.sent), 1)
+
+    def test_a_blank_card_with_an_empty_tray_still_fails(self):
+        self.camera._tray_full = False
+        self.api.queue.append(job(89))
+
+        outcome = self.build().print_next()
+
+        self.assertEqual(outcome.kind, worker.JOB_FAILED)
+        self.assertEqual([entry["job_id"] for entry in self.api.failed], [89])
+
+
+class RefusedResultTest(WorkerTestCase):
+    """A 200 that says the job was not recorded is not a delivery.
+
+    It used to count as one: the agent forgot the card, the server kept the job
+    queued, and the next claim printed it a second time.
+    """
+
+    def test_a_refused_completion_is_kept_locally(self):
+        self.api.queue.append(job(90))
+        self.api.mark_printed = lambda *args, **kwargs: {"marked": False}
+
+        self.build().print_next()
+
+        self.assertTrue(self.store.pending_outbox(), "the result must be kept for retry")
+        self.assertIsNotNone(self.store.job(90),
+                             "the local record is what stops a second card")
+
+    def test_the_operator_is_told(self):
+        self.api.queue.append(job(91))
+        self.api.mark_printed = lambda *args, **kwargs: {"marked": False}
+
+        self.build().print_next()
+
+        self.assertTrue(any("not recorded" in title.lower()
+                            for _key, title, _message in self.notifier.alerts))
+
+
+class AutoResumeTest(WorkerTestCase):
+    """A fault that can be seen to be fixed clears itself.
+
+    Standing at a printer to press Resume after emptying the tray is a step
+    nobody should have to take, and one that leaves the station idle until
+    somebody notices. Faults nothing can observe still wait for a human.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.camera = FakeCamera()
+
+    def test_a_pause_with_no_check_stays_paused(self):
+        printer = self.build()
+        printer.pause("Card 24-0001 came out blank.")
+
+        self.assertFalse(printer._resume_if_cleared())
+        self.assertTrue(printer.is_paused())
+
+    def test_an_emptied_tray_resumes_the_run(self):
+        self.camera._tray_full = True
+        printer = self.build()
+
+        outcome = printer.print_next()
+        printer.pause(outcome.detail, resume_when=printer._recheck)
+
+        self.assertFalse(printer._resume_if_cleared(), "a full tray is still full")
+
+        self.camera._tray_full = False
+
+        self.assertTrue(printer._resume_if_cleared())
+        self.assertFalse(printer.is_paused())
+        self.assertFalse(printer.tray_full, "the latch goes with the pause")
+
+    def test_a_cleared_jam_resumes_the_run(self):
+        self.printer.jam()
+        printer = self.build()
+
+        outcome = printer.print_next()
+        printer.pause(outcome.detail, resume_when=printer._recheck)
+
+        self.assertEqual(outcome.kind, worker.BLOCKED)
+        self.assertFalse(printer._resume_if_cleared())
+
+        self.printer.clear()
+
+        self.assertTrue(printer._resume_if_cleared())
+        self.assertEqual(self.api.resumed_batches, [77],
+                         "the server has to hear the batch is running again")
+
+    def test_a_jam_cleared_onto_a_full_tray_stays_paused(self):
+        self.printer.jam()
+        self.camera._tray_full = True
+        printer = self.build()
+
+        printer.pause(printer.print_next().detail, resume_when=printer._recheck)
+        self.printer.clear()
+
+        self.assertFalse(printer._resume_if_cleared())
 
 
 if __name__ == "__main__":

--- a/print-agent/tests/test_zebra.py
+++ b/print-agent/tests/test_zebra.py
@@ -126,6 +126,42 @@ class ClassifyTest(unittest.TestCase):
     def test_alarm_text_is_matched(self):
         self.assertEqual(zebra.classify(reading(alarms=["card_jam_at_flipper"])), zebra.CARD_JAM)
 
+    def test_an_empty_ribbon_is_a_stop_however_it_is_spelled(self):
+        # Observed on the real ZXP9: "RIBBON EMPTY". It matched only the bare
+        # "ribbon" catch-all and came out as a low ribbon, which is a warning
+        # the queue prints straight through -- on a printer that cannot print.
+        for text in ("RIBBON EMPTY", "ribbon_empty", "out of ribbon", "no ribbon"):
+            result = zebra.classify(reading(alarms=[text]))
+
+            self.assertEqual(result, zebra.RIBBON_OUT, text)
+            self.assertTrue(zebra.is_stop(result), text)
+
+    def test_an_empty_film_is_a_stop_however_it_is_spelled(self):
+        for text in ("FILM EMPTY", "film_empty", "out of film", "no film"):
+            result = zebra.classify(reading(alarms=[text]))
+
+            self.assertEqual(result, zebra.FILM_OUT, text)
+            self.assertTrue(zebra.is_stop(result), text)
+
+    def test_a_low_ribbon_still_reads_as_low(self):
+        # The catch-all underneath the exhausted spellings still has to work.
+        self.assertEqual(zebra.classify(reading(alarms=["ribbon low"])), zebra.RIBBON_LOW)
+
+    def test_more_spellings_of_a_stop(self):
+        cases = [
+            ("SERVICE REQUIRED", zebra.SERVICE_REQUIRED),
+            ("mechanical error", zebra.SERVICE_REQUIRED),
+            ("COVER OPEN", zebra.COVER_OPEN),
+            ("head open", zebra.COVER_OPEN),
+            ("lid_open", zebra.COVER_OPEN),
+            ("feeder empty", zebra.CARDS_OUT),
+            ("out of cards", zebra.CARDS_OUT),
+            ("output full", zebra.REJECT_BIN_FULL),
+        ]
+
+        for text, expected in cases:
+            self.assertEqual(zebra.classify(reading(alarms=[text])), expected, text)
+
     def test_none_alarms_are_ignored(self):
         # "none" in all three slots is the healthy reading on real hardware.
         self.assertEqual(zebra.classify(reading(alarms=["none", "none", "none"])), zebra.OK)

--- a/tests/Feature/Manage/PrintJobsTest.php
+++ b/tests/Feature/Manage/PrintJobsTest.php
@@ -514,8 +514,15 @@ test('the status picker offers only the edges the machine allows', function () {
         ->assertSuccessful()
         ->assertInertia(fn (Assert $page) => $page
             ->component('Manage/PrintJobs/Form')
+            // Printed and Failed are on the list because a queued card can turn out to
+            // have been printed already: the agent reports a card late when its lease
+            // lapsed mid-print, and an operator holding the card can record the same
+            // thing here. Both go through markPrinted() / markFailed(), so the badge is
+            // promoted and the batch settled exactly as an agent's report would.
             ->where('statusOptions', [
                 ['value' => 'pending', 'label' => 'Pending'],
+                ['value' => 'printed', 'label' => 'Printed'],
+                ['value' => 'failed', 'label' => 'Failed'],
                 ['value' => 'cancelled', 'label' => 'Cancelled'],
             ])
         );
@@ -614,7 +621,7 @@ test('a status the machine would refuse is rejected by the request', function ()
         ->put(route('admin.print-jobs.update', $job), [
             'printer_id' => $this->printer->id,
             'type' => 'badge',
-            'status' => 'printed',
+            'status' => 'printing',
         ])
         ->assertSessionHasErrors('status');
 

--- a/tests/Feature/PrintAgent/AgentApiTest.php
+++ b/tests/Feature/PrintAgent/AgentApiTest.php
@@ -219,3 +219,104 @@ it('records agent liveness on every call', function () {
     expect($machine->fresh()->agent_last_seen_at)->not->toBeNull()
         ->and($machine->fresh()->agent_version)->toBe('1.0.0');
 });
+
+/*
+ * Late results. The lease says how long a claim survives an agent that has died;
+ * it does not decide who printed a card. An agent that lost the network mid-run
+ * still holds the card, and has to be able to say so when it comes back - the
+ * alternative is a printed card sitting in the queue waiting to be printed again.
+ */
+
+it('accepts a completion for a job whose lease was reaped', function () {
+    [, , $batch] = agentSetup(1);
+    $job = $this->postJson('/api/print-agent/jobs/claim', ['batch_id' => $batch->id])->json('job');
+
+    $this->postJson("/api/print-agent/jobs/{$job['id']}/printing")->assertOk();
+
+    // The network drops for longer than the lease, and the reaper hands the card
+    // back to the queue while it is physically printing.
+    $this->travel(20)->minutes();
+    $this->artisan('printing:reap-leases')->assertSuccessful();
+
+    expect(PrintJob::find($job['id'])->status)->toBe(PrintJobStatusEnum::Pending);
+
+    $this->postJson("/api/print-agent/jobs/{$job['id']}/printed", [
+        'completion_source' => 'firmware',
+        'firmware_job_id' => '58',
+    ])->assertOk()->assertJson(['marked' => true]);
+
+    expect(PrintJob::find($job['id'])->status)->toBe(PrintJobStatusEnum::Printed);
+});
+
+it('accepts a failure for a job whose lease was reaped', function () {
+    [, , $batch] = agentSetup(1);
+    $job = $this->postJson('/api/print-agent/jobs/claim', ['batch_id' => $batch->id])->json('job');
+
+    $this->travel(20)->minutes();
+    $this->artisan('printing:reap-leases')->assertSuccessful();
+
+    $this->postJson("/api/print-agent/jobs/{$job['id']}/failed", ['reason' => 'Ribbon out'])
+        ->assertOk()
+        ->assertJson(['status' => 'failed', 'batch_status' => 'paused']);
+});
+
+it('treats a repeated completion as recorded rather than refused', function () {
+    // The agent's outbox resends anything it never got a reply to, so a delivery
+    // that crossed with a network drop arrives twice. Answering the repeat with
+    // "not marked" made the agent alert about a card that is recorded fine.
+    [, , $batch] = agentSetup(1);
+    $job = $this->postJson('/api/print-agent/jobs/claim', ['batch_id' => $batch->id])->json('job');
+
+    $this->postJson("/api/print-agent/jobs/{$job['id']}/printing")->assertOk();
+    $this->postJson("/api/print-agent/jobs/{$job['id']}/printed", ['completion_source' => 'firmware'])
+        ->assertOk()
+        ->assertJson(['marked' => true]);
+
+    $this->postJson("/api/print-agent/jobs/{$job['id']}/printed", ['completion_source' => 'firmware'])
+        ->assertOk()
+        ->assertJson(['marked' => true, 'already_recorded' => true]);
+});
+
+it('refuses a late failure for a card that is already printed', function () {
+    [, , $batch] = agentSetup(1);
+    $job = $this->postJson('/api/print-agent/jobs/claim', ['batch_id' => $batch->id])->json('job');
+
+    $this->postJson("/api/print-agent/jobs/{$job['id']}/printing")->assertOk();
+    $this->postJson("/api/print-agent/jobs/{$job['id']}/printed", ['completion_source' => 'firmware'])->assertOk();
+
+    $this->postJson("/api/print-agent/jobs/{$job['id']}/failed", ['reason' => 'Card jam'])
+        ->assertStatus(409);
+
+    expect(PrintJob::find($job['id'])->status)->toBe(PrintJobStatusEnum::Printed)
+        ->and($batch->fresh()->status)->not->toBe(PrintBatchStatusEnum::Paused);
+});
+
+it('refuses a late result for a job another machine has since claimed', function () {
+    [, $printer, $batch] = agentSetup(1);
+    $job = $this->postJson('/api/print-agent/jobs/claim', ['batch_id' => $batch->id])->json('job');
+
+    $this->travel(20)->minutes();
+    $this->artisan('printing:reap-leases')->assertSuccessful();
+
+    // Somebody else picked the card up in the meantime. Overwriting their work
+    // with our late result is how one badge becomes two cards.
+    PrintJob::find($job['id'])->claim(Machine::factory()->create());
+
+    $this->postJson("/api/print-agent/jobs/{$job['id']}/printed", ['completion_source' => 'firmware'])
+        ->assertStatus(409);
+
+    expect(PrintJob::find($job['id'])->status)->toBe(PrintJobStatusEnum::Queued);
+});
+
+it('keeps a claim alive for long enough to print a card', function () {
+    // A ZXP9 warming up can hold the Windows spooler for minutes with no
+    // heartbeat getting out. At three minutes the reaper took the card back
+    // while it was printing, and the badge was queued again behind it.
+    [, , $batch] = agentSetup(1);
+    $job = $this->postJson('/api/print-agent/jobs/claim', ['batch_id' => $batch->id])->json('job');
+
+    $this->travel(10)->minutes();
+    $this->artisan('printing:reap-leases')->assertSuccessful();
+
+    expect(PrintJob::find($job['id'])->status)->toBe(PrintJobStatusEnum::Queued);
+});

--- a/tests/Unit/Enum/PrintJobStatusEnumTest.php
+++ b/tests/Unit/Enum/PrintJobStatusEnumTest.php
@@ -13,8 +13,13 @@ class PrintJobStatusEnumTest extends TestCase
 
         $this->assertTrue($status->canTransitionTo(PrintJobStatusEnum::Queued));
         $this->assertTrue($status->canTransitionTo(PrintJobStatusEnum::Cancelled));
-        $this->assertFalse($status->canTransitionTo(PrintJobStatusEnum::Printed));
         $this->assertFalse($status->canTransitionTo(PrintJobStatusEnum::Printing));
+
+        // A reaped job is Pending again while the agent that claimed it may still
+        // have the card in the printer. It has to be able to report the outcome
+        // late, or the card is handed out and printed a second time.
+        $this->assertTrue($status->canTransitionTo(PrintJobStatusEnum::Printed));
+        $this->assertTrue($status->canTransitionTo(PrintJobStatusEnum::Failed));
     }
 
     public function test_can_transition_from_queued()


### PR DESCRIPTION
A card that was printing went back to Pending, and a full tray could lose one. Both come down to the same thing: a timer deciding what happened to a card instead of the agent that held it.

## Leases

`LEASE_SECONDS` was 180, which is less than a card takes. A ZXP9 warming up leaves the Windows spooler holding the bytes for minutes with no heartbeat getting out, so `printing:reap-leases` handed the job back to the queue while it was physically printing.

- The lease is now 900s, and it is documented as what it is: recovery for a dead agent, not a print timeout.
- `Pending -> Printed` and `Pending -> Failed` are legal edges. An agent that lost the network still holds the card and reports it when it comes back, rather than leaving a printed card in the queue to be printed again.
- The endpoint decides who may say so: only the machine that owns the printer, only while nobody else holds the job. A job reclaimed in the meantime gets a 409.
- A repeated `printed` for a job already recorded is answered as recorded, not refused. The agent's outbox resends anything it never got a reply to.
- The agent keeps a lease keeper thread around the blocking spool call, which was the window with no heartbeat at all.

## No double prints

- The agent refuses to print a card its local store says it already put through the printer. Already reported means send the result again; mid-print means ask the operator, because nobody here can tell whether the card is in the stack; only a job that never reached the spooler is printed.
- A 200 that says `marked: false` is no longer counted as delivered. It used to be: the agent forgot the card, the server kept the job queued, and the next claim printed it again.

## The heating phase

`firmware_timeout` was a hard three minutes, so a six minute card was reported on the spooler's word alone while it was still in the machine, and the camera was then asked about a bin that was still empty. It now bounds silence rather than print time: while a job row is in flight or the printer says it is printing or warming up, the deadline is pushed forward, with a twenty minute ceiling so a printer stuck in "printing" still ends.

## A full tray is not a blank card

The ink points are calibrated for a card lying where cards normally land. Once the stack has risen they read the bin, the rim or a card standing half out of the chute, which is bright and colourless and therefore indistinguishable from bare stock. A blank verdict taken while the tray reads full now reports the card, honestly unverified, and stops the run for the tray. Failing it put a badge that was sitting in the tray back in the queue for a second card.

## Faults that clear themselves

Emptying the tray, clearing a jam or closing the cover resumes the run without anybody pressing Resume: the pause carries the check that would have to pass, and a jam cleared onto a still-full tray stays paused. A blank card or an unanswered reprint question carries no check and still waits for a person.

## Printer states

- `RIBBON EMPTY` matched only the bare `ribbon` catch-all and was reported as a low ribbon, which is a warning the queue prints straight through. Every exhausted spelling now sits above the catch-all, for ribbon, film and cards, along with `output full`, `mechanical error` and `head`/`lid open`.
- A fault word in the state field is no longer treated as an unknown state. The printer puts `COVER OPEN` and `SERVICE REQUIRED` there as well as in an alarm slot, and the journal was announcing both as something nobody understood.
- The log line names the strings it could not explain, so mapping a new fault does not mean opening a file on the print station.

## Tests

1236 Laravel tests pass, and all 18 agent test files. New coverage: late completion after a reap, 409 on a reclaimed job, the repeat completion, a six minute heating cycle confirmed by firmware with the lease renewed across it, the bounded ceiling, the store guard against a second card, the tray-full blank verdict, and auto-resume including the jam cleared onto a full tray.
