### PR TITLE
Stop moving the print approval cutoff

### DIFF
--- a/app/Http/Controllers/Manage/BadgeController.php
+++ b/app/Http/Controllers/Manage/BadgeController.php
@@ -598,9 +598,10 @@ class BadgeController extends Controller
 
             // The print cutoff. Everything approved before the last run is already printed
             // and filed, so the next run only wants what came in after it; without this the
-            // list re-offers the whole backlog on every run. BadgePrintController::bulk()
-            // sets `approved_from` to the newest badge it just queued, and the redirect
-            // carries it back onto the list.
+            // list re-offers the whole backlog on every run. Set by the operator and left
+            // alone by everything else: printing used to move this bound to the newest
+            // approval in the run it had just queued, which narrowed the list under whoever
+            // was working it on every press of Print.
             Filter::datetime('approved_from', 'Approved from')
                 ->chipLabel('Approved after')
                 ->apply(fn (Builder $query, string $value) => $this->applyApprovedBound($query, '>=', $value)),

--- a/app/Http/Controllers/Manage/BadgePrintController.php
+++ b/app/Http/Controllers/Manage/BadgePrintController.php
@@ -15,7 +15,6 @@ use App\Models\Badge\State_Fulfillment\Processing;
 use App\Support\Manage\Action;
 use App\Support\Manage\Status;
 use App\Support\Manage\Toast;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Collection;
@@ -170,52 +169,17 @@ class BadgePrintController extends Controller
             $this->queuedBody($batch),
         );
 
-        return $this->backWithCutoff($badges);
-    }
-
-    /**
-     * Back to the list, with the approval cutoff moved past the run just queued.
-     *
-     * These badges are about to come off the printer and be filed, so the operator's next
-     * run wants what was approved after the newest of them and nothing before it. Writing
-     * the bound into `filter[approved_from]` is what makes that the default next view
-     * rather than something to set by hand between every run.
-     *
-     * The bound is the newest `approved_at` in the run rather than now(), because a badge
-     * approved between the operator ticking the boxes and pressing Print was never in this
-     * batch and must not be filtered away by it.
-     *
-     * A run whose badges carry no approval timestamp leaves the filter alone; there is no
-     * cutoff to be had, and overwriting a good one with a blank would be worse than
-     * leaving it.
-     *
-     * @param  EloquentCollection<int, Badge>  $badges
-     */
-    private function backWithCutoff(EloquentCollection $badges): RedirectResponse
-    {
-        // Parsed rather than read straight off the model: Fursuit does not cast
-        // `approved_at`, so these are raw strings from the driver.
-        $newest = $badges->loadMissing('fursuit')
-            ->pluck('fursuit.approved_at')
-            ->filter()
-            ->map(fn ($at) => Carbon::parse($at))
-            ->max();
-
-        if (! $newest) {
-            return back();
-        }
-
-        $target = back()->getTargetUrl();
-        $parts = parse_url($target);
-        parse_str($parts['query'] ?? '', $query);
-
-        // The control the chip renders is a datetime-local, whose value has no zone and no
-        // seconds; anything else round-trips into a blank box.
-        $query['filter']['approved_from'] = $newest->format('Y-m-d\TH:i');
-
-        return redirect()->to(
-            ($parts['path'] ?? '/').'?'.http_build_query($query)
-        );
+        /*
+         * Straight back to the list the operator was on, filters untouched.
+         *
+         * A print used to rewrite `filter[approved_from]` to the newest approval in the run
+         * on the way back, on the reasoning that the next run only wants what came in after
+         * this one. In practice it moved the cutoff on every press of Print - including a
+         * press that queued nothing new - so the list an operator had set up narrowed itself
+         * under them and cards approved before the bound dropped out of view without anybody
+         * asking for that. The filter stays, and stays theirs to set.
+         */
+        return back();
     }
 
     /**

--- a/tests/Feature/Manage/BadgePrintTest.php
+++ b/tests/Feature/Manage/BadgePrintTest.php
@@ -34,7 +34,6 @@ use App\Models\Fursuit\Fursuit;
 use App\Models\Species;
 use App\Models\User;
 use App\Support\Manage\EventScope;
-use Carbon\Carbon;
 use Illuminate\Support\Facades\Storage;
 
 use function Pest\Laravel\actingAs;
@@ -501,49 +500,28 @@ test('a user who cannot see badges is offered no print action at all', function 
     expect(actingAs($this->nobody)->get(route('admin.badges.index'))->status())->toBe(403);
 });
 
-test('the bulk action moves the approval cutoff past the run it just queued', function () {
+test('the bulk action leaves the list filters exactly as it found them', function () {
     $early = ($this->badge)('0100-1');
     $late = ($this->badge)('0200-1');
 
     $early->fursuit->update(['approved_at' => now()->subHours(2)]);
     $late->fursuit->update(['approved_at' => now()->subMinutes(10)]);
 
-    // The operator is standing on a filtered list, and lands back on it.
-    $from = route('admin.badges.index', ['filter' => ['status_payment' => ['paid']]]);
+    /*
+     * A print used to rewrite `filter[approved_from]` to the newest approval in the run on
+     * the way back, so the list narrowed itself on every press of Print - including one that
+     * queued nothing new - and cards approved before the bound left the view without anybody
+     * asking. The operator owns that filter now, so the redirect is the plain one back.
+     */
+    $from = route('admin.badges.index', [
+        'filter' => ['status_payment' => ['paid'], 'approved_from' => '2026-08-08T09:00'],
+    ]);
 
-    $response = actingAs($this->admin)
+    actingAs($this->admin)
         ->from($from)
         ->post(route('admin.badges.bulk.print'), [
             'ids' => [$early->id, $late->id],
             'printer_id' => $this->printer->id,
-        ]);
-
-    // The bound is the newest badge in the run, in the format the datetime-local control
-    // round-trips, and the rest of the query string survives.
-    $target = $response->headers->get('Location');
-
-    parse_str(parse_url($target, PHP_URL_QUERY) ?: '', $query);
-
-    // Parsed, because Fursuit does not cast `approved_at`: it comes back a raw string.
-    expect($query['filter']['approved_from'])
-        ->toBe(Carbon::parse($late->fursuit->fresh()->approved_at)->format('Y-m-d\TH:i'))
-        ->and($query['filter']['status_payment'])->toBe(['paid']);
-});
-
-test('a run with no approval timestamps leaves the cutoff alone', function () {
-    $badge = ($this->badge)();
-
-    $badge->fursuit->update(['approved_at' => null]);
-
-    // Overwriting a good cutoff with a blank would be worse than not moving it.
-    $from = route('admin.badges.index', ['filter' => ['approved_from' => '2026-08-08T09:00']]);
-
-    $response = actingAs($this->admin)
-        ->from($from)
-        ->post(route('admin.badges.bulk.print'), [
-            'ids' => [$badge->id],
-            'printer_id' => $this->printer->id,
-        ]);
-
-    $response->assertRedirect($from);
+        ])
+        ->assertRedirect($from);
 });


### PR DESCRIPTION
Mass-printing badges rewrote the list's own filter on the way back. `BadgePrintController::bulk()` ended in `backWithCutoff()`, which took the newest `fursuit.approved_at` in the run and wrote it into `filter[approved_from]` on the redirect URL.

The idea was that the next run only wants what was approved after the last one. In practice the bound moved on every press of Print - including a press that queued nothing new, since a reprint of already-printed cards still produces a batch and still carries their old approval timestamps forward. The list an operator had set up narrowed itself under them, and badges approved before the new bound left the view without anyone asking for it.

So the redirect is now the plain `back()`. The "Approved from" filter itself stays exactly as it is, on the operator's terms: they set it, and nothing else moves it.

## Changes

- `BadgePrintController`: `backWithCutoff()` and its `Carbon` import removed; `bulk()` returns `back()`.
- `BadgeController`: the filter's comment no longer describes a caller that writes to it.
- `BadgePrintTest`: the two cutoff tests are replaced by one that prints from a filtered list carrying `approved_from` and asserts the redirect lands back on that exact URL.

Full suite: 1268 passed, 11 skipped.
